### PR TITLE
Bump pdp client med caching av token

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ postgresqlVersion=42.7.4
 kotlinterVersion=4.4.1
 h2_version=2.3.232
 kafkaVersion=3.8.0
-pdpClientVersion=0.0.2
+pdpClientVersion=0.0.3

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/auth/AltinnAuthClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/auth/AltinnAuthClient.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import no.nav.helsearbeidsgiver.Env
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 
 class AltinnAuthClient {
     @Serializable
@@ -37,6 +38,7 @@ class AltinnAuthClient {
 
     fun getToken(): String =
         runBlocking {
+            sikkerLogger().info("Henter nytt token fra maskinporten og altinn")
             val texasTokenEndpoint = Env.getProperty("NAIS_TOKEN_ENDPOINT")
             val altinn3BaseUrl = Env.getProperty("ALTINN_3_BASE_URL")
             val altinnPdpScope = Env.getProperty("ALTINN_PDP_SCOPE")


### PR DESCRIPTION
Oppdaterer pdp client. Ny versjon har caching av altinn token.
Legger også på logging når nytt token hentes