### PR TITLE
Legg til maskinporten scope for dialogporten i dev

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -48,6 +48,8 @@ spec:
           name: im.read
       consumes:
         - name: "altinn:authorization/authorize"
+        - name: "digdir:dialogporten.serviceprovider"
+
   gcp:
     sqlInstances:
       - type: POSTGRES_16


### PR DESCRIPTION
Scopet gir tilgang til dialogporten sitt api for å opprette, endre og lese dialoger i dialogporten