### PR TITLE
Opprett dialoger for forespørsler

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -65,4 +65,6 @@ spec:
       value: "nav_sykepenger_inntektsmelding-nedlasting"
     - name: ALTINN_PDP_SCOPE
       value: "altinn:authorization/authorize"
+    - name: DIALOGPORTEN_SCOPE
+      value: "digdir:dialogporten.serviceprovider"
 

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -69,4 +69,6 @@ spec:
       value: "altinn:authorization/authorize"
     - name: DIALOGPORTEN_SCOPE
       value: "digdir:dialogporten.serviceprovider"
+    - name: IM_DIALOG_BASEURL
+      value: "https://arbeidsgiver.intern.dev.nav.no"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,8 @@ val h2_version: String by project
 val kafkaVersion: String by project
 val coroutineVersion: String by project
 val pdpClientVersion: String by project
+val dialogportenClientVersion: String by project
+
 
 plugins {
     kotlin("jvm") version "2.0.0"
@@ -72,6 +74,7 @@ dependencies {
     implementation("org.postgresql:postgresql:$postgresqlVersion")
     implementation("com.zaxxer:HikariCP:$hikariVersion")
     implementation("no.nav.helsearbeidsgiver:altinn-pdp-client:$pdpClientVersion")
+    implementation("no.nav.helsearbeidsgiver:dialogporten-client:$dialogportenClientVersion")
     implementation("no.nav.security:token-validation-ktor-v2:$tokenSupportVersion")
     testImplementation("io.ktor:ktor-server-tests-jvm")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,5 +101,6 @@ tasks {
         environment("database.embedded", "true")
         environment("EKSPONERT_MASKINPORTEN_SCOPES", "nav:helse/im.read")
         environment("MASKINPORTEN_WELL_KNOWN_URL", "http://localhost:33445/maskinporten/.well-known/openid-configuration")
+        environment("IM_DIALOG_BASEURL", "https://arbeidsgiver.intern.dev.nav.no")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,4 @@ kotlinterVersion=4.4.1
 h2_version=2.3.232
 kafkaVersion=3.8.0
 pdpClientVersion=0.0.6
+dialogportenClientVersion=0.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ kotlinterVersion=4.4.1
 h2_version=2.3.232
 kafkaVersion=3.8.0
 pdpClientVersion=0.0.6
-dialogportenClientVersion=0.0.1
+dialogportenClientVersion=0.0.2

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/Application.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/Application.kt
@@ -16,10 +16,8 @@ import no.nav.helsearbeidsgiver.auth.AltinnAuthClient
 import no.nav.helsearbeidsgiver.auth.gyldigScope
 import no.nav.helsearbeidsgiver.auth.gyldigSystembrukerOgConsumer
 import no.nav.helsearbeidsgiver.db.Database
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
 import no.nav.helsearbeidsgiver.dialogporten.IDialogportenService
 import no.nav.helsearbeidsgiver.dialogporten.IngenDialogportenService
-import no.nav.helsearbeidsgiver.dialogporten.lagDialogportenClient
 import no.nav.helsearbeidsgiver.forespoersel.ForespoerselRepository
 import no.nav.helsearbeidsgiver.forespoersel.ForespoerselService
 import no.nav.helsearbeidsgiver.inntektsmelding.InntektsmeldingRepository
@@ -51,7 +49,8 @@ fun main() {
 fun startServer() {
     val authClient = AltinnAuthClient()
     val pdpService = if (isDev()) PdpService(lagPdpClient(authClient)) else IngenTilgangPdpService()
-    val dialogService = if (isDev()) DialogportenService(lagDialogportenClient(authClient)) else IngenDialogportenService()
+    // val dialogService = if (isDev()) DialogportenService(lagDialogportenClient(authClient)) else IngenDialogportenService()
+    val dialogService = IngenDialogportenService()
     embeddedServer(
         factory = Netty,
         port = 8080,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/Application.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/Application.kt
@@ -12,9 +12,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import no.nav.helsearbeidsgiver.Env.getProperty
 import no.nav.helsearbeidsgiver.Env.getPropertyOrNull
+import no.nav.helsearbeidsgiver.auth.AltinnAuthClient
 import no.nav.helsearbeidsgiver.auth.gyldigScope
 import no.nav.helsearbeidsgiver.auth.gyldigSystembrukerOgConsumer
 import no.nav.helsearbeidsgiver.db.Database
+import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.IDialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.IngenDialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.lagDialogportenClient
 import no.nav.helsearbeidsgiver.forespoersel.ForespoerselRepository
 import no.nav.helsearbeidsgiver.forespoersel.ForespoerselService
 import no.nav.helsearbeidsgiver.inntektsmelding.InntektsmeldingRepository
@@ -44,16 +49,21 @@ fun main() {
 }
 
 fun startServer() {
-    val pdpService = if (isDev()) PdpService(lagPdpClient()) else IngenTilgangPdpService()
+    val authClient = AltinnAuthClient()
+    val pdpService = if (isDev()) PdpService(lagPdpClient(authClient)) else IngenTilgangPdpService()
+    val dialogService = if (isDev()) DialogportenService(lagDialogportenClient(authClient)) else IngenDialogportenService()
     embeddedServer(
         factory = Netty,
         port = 8080,
-        module = { apiModule(pdpService = pdpService) },
+        module = { apiModule(pdpService = pdpService, dialogportenService = dialogService) },
     ).start(wait = true)
 }
 
 @Suppress("unused")
-fun Application.apiModule(pdpService: IPdpService) {
+fun Application.apiModule(
+    pdpService: IPdpService,
+    dialogportenService: IDialogportenService,
+) {
     sikkerLogger().info("Starter applikasjon!")
     val db = Database.init()
     val inntektsmeldingRepository = InntektsmeldingRepository(db)
@@ -82,6 +92,7 @@ fun Application.apiModule(pdpService: IPdpService) {
                 ForespoerselTolker(
                     forespoerselRepository,
                     mottakRepository,
+                    dialogportenService,
                 ),
             )
         }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/auth/AltinnAuthClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/auth/AltinnAuthClient.kt
@@ -36,12 +36,11 @@ class AltinnAuthClient {
             }
         }
 
-    fun getToken(): String =
+    fun getToken(scope: String): String =
         runBlocking {
             sikkerLogger().info("Henter nytt token fra maskinporten og altinn")
             val texasTokenEndpoint = Env.getProperty("NAIS_TOKEN_ENDPOINT")
             val altinn3BaseUrl = Env.getProperty("ALTINN_3_BASE_URL")
-            val altinnPdpScope = Env.getProperty("ALTINN_PDP_SCOPE")
             val maskinportenToken: String =
                 httpClient
                     .post(texasTokenEndpoint) {
@@ -49,7 +48,7 @@ class AltinnAuthClient {
                         setBody(
                             listOf(
                                 "identity_provider" to "maskinporten",
-                                "target" to altinnPdpScope,
+                                "target" to scope,
                             ).formUrlEncode(),
                         )
                     }.body<TokenResponse>()
@@ -63,3 +62,7 @@ class AltinnAuthClient {
             altinnToken
         }
 }
+
+fun AltinnAuthClient.getPdpToken() = getToken(scope = Env.getProperty("ALTINN_PDP_SCOPE"))
+
+fun AltinnAuthClient.getDialogportenToken() = getToken(scope = Env.getProperty("DIALOGPORTEN_SCOPE"))

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/Dialogporten.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/Dialogporten.kt
@@ -33,7 +33,7 @@ class IngenDialogportenService : IDialogportenService {
 class DialogportenService(
     val dialogportenClient: DialogportenClient,
 ) : IDialogportenService {
-    val imDalogUrl = ""
+    private val imDalogBaseUrl = Env.getProperty("IM_DIALOG_BASEURL")
 
     override fun opprettDialog(
         orgnr: String,
@@ -43,7 +43,7 @@ class DialogportenService(
             dialogportenClient
                 .opprettDialog(
                     orgnr = orgnr,
-                    url = "$imDalogUrl/$forespoerselId",
+                    url = "$imDalogBaseUrl/im-dialog/$forespoerselId",
                 ).onFailure { e -> sikkerLogger().error("Fikk feil mot dialogporten", e) }
                 .onSuccess { dialogId ->
                     sikkerLogger().info(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/Dialogporten.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/Dialogporten.kt
@@ -1,0 +1,64 @@
+package no.nav.helsearbeidsgiver.dialogporten
+
+import kotlinx.coroutines.runBlocking
+import no.nav.helsearbeidsgiver.Env
+import no.nav.helsearbeidsgiver.auth.AltinnAuthClient
+import no.nav.helsearbeidsgiver.auth.getDialogportenToken
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import java.util.UUID
+
+interface IDialogportenService {
+    fun opprettDialog(
+        orgnr: String,
+        forespoerselId: UUID,
+    ): Result<String>
+}
+
+class IngenDialogportenService : IDialogportenService {
+    override fun opprettDialog(
+        orgnr: String,
+        forespoerselId: UUID,
+    ): Result<String> {
+        val generertId = UUID.randomUUID()
+        sikkerLogger().info(
+            "Oppretter ikke dialog for forespoerselId: {}, på orgnr: {}, generertId: {}",
+            forespoerselId,
+            orgnr,
+            generertId,
+        )
+        return Result.success(generertId.toString())
+    }
+}
+
+class DialogportenService(
+    val dialogportenClient: DialogportenClient,
+) : IDialogportenService {
+    val imDalogUrl = ""
+
+    override fun opprettDialog(
+        orgnr: String,
+        forespoerselId: UUID,
+    ): Result<String> =
+        runBlocking {
+            dialogportenClient
+                .opprettDialog(
+                    orgnr = orgnr,
+                    url = "$imDalogUrl/$forespoerselId",
+                ).onFailure { e -> sikkerLogger().error("Fikk feil mot dialogporten", e) }
+                .onSuccess { dialogId ->
+                    sikkerLogger().info(
+                        "Opprettet dialog for forespoerselId: {}, på orgnr: {}, med dialogId: {}",
+                        forespoerselId,
+                        orgnr,
+                        dialogId,
+                    )
+                }
+        }
+}
+
+fun lagDialogportenClient(authClient: AltinnAuthClient) =
+    DialogportenClient(
+        baseUrl = Env.getProperty("ALTINN_3_BASE_URL"),
+        ressurs = Env.getProperty("ALTINN_IM_RESSURS"),
+        getToken = authClient::getDialogportenToken,
+    )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/pdp/PdpService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/pdp/PdpService.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.helsearbeidsgiver.Env
 import no.nav.helsearbeidsgiver.altinn.pdp.PdpClient
 import no.nav.helsearbeidsgiver.auth.AltinnAuthClient
+import no.nav.helsearbeidsgiver.auth.getPdpToken
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 
 interface IPdpService {
@@ -42,17 +43,16 @@ class IngenTilgangPdpService : IPdpService {
     }
 }
 
-fun lagPdpClient(): PdpClient {
+fun lagPdpClient(authClient: AltinnAuthClient): PdpClient {
     val altinn3BaseUrl = Env.getProperty("ALTINN_3_BASE_URL")
     val subscriptionKey = Env.getProperty("SUBSCRIPTION_KEY")
     val altinnImRessurs = Env.getProperty("ALTINN_IM_RESSURS")
-    val altinnAuthClient = AltinnAuthClient()
     val pdpClient =
         PdpClient(
             altinn3BaseUrl,
             subscriptionKey,
             altinnImRessurs,
-            altinnAuthClient::getToken,
+            authClient::getPdpToken,
         )
     return pdpClient
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/authorization/ApiTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/authorization/ApiTest.kt
@@ -13,6 +13,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import no.nav.helsearbeidsgiver.apiModule
 import no.nav.helsearbeidsgiver.db.Database
+import no.nav.helsearbeidsgiver.dialogporten.IDialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.IngenDialogportenService
 import no.nav.helsearbeidsgiver.forespoersel.ForespoerselRepository
 import no.nav.helsearbeidsgiver.forespoersel.ForespoerselResponse
 import no.nav.helsearbeidsgiver.forespoersel.Status
@@ -36,6 +38,7 @@ class ApiTest {
     private val testApplication: TestApplication
     private val client: HttpClient
     private val pdpService: PdpService
+    private val dialogportenService: IDialogportenService
 
     init {
         mockOAuth2Server =
@@ -45,10 +48,11 @@ class ApiTest {
         db = Database.init()
         forespoerselRepo = ForespoerselRepository(db)
         pdpService = PdpService(mockk(relaxed = true))
+        dialogportenService = IngenDialogportenService()
         every { pdpService.harTilgang(any(), any()) } returns true
         testApplication =
             TestApplication {
-                application { apiModule(pdpService = pdpService) }
+                application { apiModule(pdpService = pdpService, dialogportenService = dialogportenService) }
             }
         client =
             testApplication.createClient {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
@@ -1,0 +1,31 @@
+package no.nav.helsearbeidsgiver.dialogporten
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class DialogportenServiceTest {
+    val mockDialogportenClient = mockk<DialogportenClient>()
+    val dialogportenService = DialogportenService(mockDialogportenClient)
+
+    @Test
+    fun `dialogporten klient videresender resultatet`() {
+        val orgnr = "1234"
+        val forespoereslId = UUID.randomUUID()
+        val forventetDialogId = UUID.randomUUID()
+        coEvery { mockDialogportenClient.opprettDialog(any(), any()) } returns Result.success(forventetDialogId.toString())
+
+        dialogportenService.opprettDialog(orgnr, forespoereslId).getOrThrow() shouldBe forventetDialogId.toString()
+    }
+
+    @Test
+    fun `dialogporten service kaster ikke feil`() {
+        val orgnr = "1234"
+        val forespoereslId = UUID.randomUUID()
+        coEvery { mockDialogportenClient.opprettDialog(any(), any()) } returns Result.failure(DialogportenClientException())
+        shouldNotThrow<DialogportenClientException> { dialogportenService.opprettDialog(orgnr, forespoereslId) }
+    }
+}

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/KafkaErrorHandlingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/KafkaErrorHandlingTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.helsearbeidsgiver.db.Database
+import no.nav.helsearbeidsgiver.dialogporten.IDialogportenService
 import no.nav.helsearbeidsgiver.forespoersel.ForespoerselRepository
 import no.nav.helsearbeidsgiver.kafka.forespoersel.ForespoerselTolker
 import no.nav.helsearbeidsgiver.mottak.MottakRepository
@@ -21,7 +22,8 @@ class KafkaErrorHandlingTest {
 
     val forespoerselRepository = ForespoerselRepository(db)
     val mockMottakRepository = mockk<MottakRepository>()
-    val forespoerselTolker = ForespoerselTolker(forespoerselRepository, mockMottakRepository)
+    val mockDialogportenService = mockk<IDialogportenService>()
+    val forespoerselTolker = ForespoerselTolker(forespoerselRepository, mockMottakRepository, mockDialogportenService)
 
     @BeforeEach
     fun init() {
@@ -41,7 +43,7 @@ class KafkaErrorHandlingTest {
     fun `ugyldig forespørsel i forespørselMottatt-melding skal bare lagre til mottak og gå videre`() {
         every { mockMottakRepository.opprett(any()) } returns 100
         val mockForespoerselRepository = mockk<ForespoerselRepository>()
-        val mockConsumer = ForespoerselTolker(mockForespoerselRepository, mockMottakRepository)
+        val mockConsumer = ForespoerselTolker(mockForespoerselRepository, mockMottakRepository, mockDialogportenService)
         mockConsumer.lesMelding(UGYLDIG_FORESPOERSEL_MOTTATT)
 
         verify(exactly = 1) { mockMottakRepository.opprett(any()) }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
@@ -48,6 +48,7 @@ class MeldingTolkerTest {
 
     @Test
     fun duplikat() {
+        every { mockDialogportenService.opprettDialog(any(), any()) } returns Result.success(UUID.randomUUID().toString())
         forespoerselTolker.lesMelding(FORESPOERSEL_MOTTATT)
         forespoerselTolker.lesMelding(FORESPOERSEL_MOTTATT)
     }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
@@ -1,6 +1,10 @@
 package no.nav.helsearbeidsgiver.kafka.inntektsmelding
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import no.nav.helsearbeidsgiver.db.Database
+import no.nav.helsearbeidsgiver.dialogporten.IDialogportenService
 import no.nav.helsearbeidsgiver.forespoersel.ForespoerselRepository
 import no.nav.helsearbeidsgiver.inntektsmelding.InntektsmeldingRepository
 import no.nav.helsearbeidsgiver.inntektsmelding.InntektsmeldingService
@@ -14,6 +18,7 @@ import no.nav.helsearbeidsgiver.utils.TestData.SIMBA_PAYLOAD
 import no.nav.helsearbeidsgiver.utils.TransactionalExtension
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.util.UUID
 
 @ExtendWith(TransactionalExtension::class)
 class MeldingTolkerTest {
@@ -23,12 +28,16 @@ class MeldingTolkerTest {
     val inntektsmeldingService = InntektsmeldingService(inntektsmeldingRepository)
     val mottakRepository = MottakRepository(db)
     val inntektsmeldingTolker = InntektsmeldingTolker(inntektsmeldingService, mottakRepository)
-    val forespoerselTolker = ForespoerselTolker(forespoerselRepository, mottakRepository)
+    val mockDialogportenService = mockk<IDialogportenService>()
+    val forespoerselTolker = ForespoerselTolker(forespoerselRepository, mottakRepository, mockDialogportenService)
 
     @Test
     fun kunLagreEventerSomMatcher() {
+        every { mockDialogportenService.opprettDialog(any(), any()) } returns Result.success(UUID.randomUUID().toString())
         // Test at kjente payloads ikke kræsjer:
         forespoerselTolker.lesMelding(FORESPOERSEL_MOTTATT)
+        verify { mockDialogportenService.opprettDialog(any(), any()) }
+
         forespoerselTolker.lesMelding(FORESPOERSEL_BESVART)
         inntektsmeldingTolker.lesMelding(IM_MOTTATT)
         inntektsmeldingTolker.lesMelding(ARBEIDSGIVER_INITIERT_IM_MOTTATT)


### PR DESCRIPTION
Lager funksjonalitet for å opprette dialoger for forespørsler.
Har disablet dette i dev og prod. Er ikke nødvendig å opprette masse dialoger som ikke er ferdig definert.