### PR TITLE
Fiks feil med kafkaconfig

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/KafkaConfig.kt
@@ -26,7 +26,7 @@ fun createKafkaConsumerConfig(consumerName: String): Properties {
             ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG to "30000",
             ConsumerConfig.CLIENT_ID_CONFIG to "sykepenger-im-lps-api-$consumerName",
         )
-    return Properties().apply { consumerKafkaProperties + commonKafkaProperties() }
+    return Properties().apply { putAll(consumerKafkaProperties + commonKafkaProperties()) }
 }
 
 fun createKafkaProducerConfig(producerName: String): Properties {
@@ -46,7 +46,7 @@ fun createKafkaProducerConfig(producerName: String): Properties {
             ProducerConfig.CLIENT_ID_CONFIG to "sykepenger-im-lps-api-$producerName",
         )
 
-    return Properties().apply { producerKafkaProperties + commonKafkaProperties() }
+    return Properties().apply { putAll(producerKafkaProperties + commonKafkaProperties()) }
 }
 
 private fun commonKafkaProperties(): Map<String, String> {


### PR DESCRIPTION
**Bakgrunn**
Jeg kom i skade for å brekke kafka-oppsettet vårt i denne [commiten her](https://github.com/navikt/sykepenger-im-lps-api/pull/29/commits/f3c1f8e239c41395d12c1395938d7d102de4c90c) da jeg samlet felles-ting for configen til produsenten og konsumentet. Dette sendte API-appen i crashloop i dev.

**Løsning**
Sleng på en `putAll` på propertiesene. Har verifisert at det nå funker igjen i dev.