### PR TITLE
La være å sende API-mottatte inntektsmeldinger videre til Simba i produksjon

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
@@ -25,6 +25,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.InntektsmeldingService
 import no.nav.helsearbeidsgiver.kafka.createKafkaConsumerConfig
 import no.nav.helsearbeidsgiver.kafka.createKafkaProducerConfig
 import no.nav.helsearbeidsgiver.kafka.forespoersel.ForespoerselTolker
+import no.nav.helsearbeidsgiver.kafka.innsending.IngenInnsendingProducer
 import no.nav.helsearbeidsgiver.kafka.innsending.InnsendingProducer
 import no.nav.helsearbeidsgiver.kafka.innsending.InnsendingSerializer
 import no.nav.helsearbeidsgiver.kafka.inntektsmelding.InntektsmeldingTolker
@@ -82,13 +83,17 @@ fun configureServices(repositories: Repositories): Services {
     val sykmeldingService = SykmeldingService(repositories.sykmeldingRepository)
 
     val innsendingProducer =
-        InnsendingProducer(
-            KafkaProducer(
-                createKafkaProducerConfig(producerName = "api-innsending-producer"),
-                StringSerializer(),
-                InnsendingSerializer(),
-            ),
-        )
+        if (isLocal() || isDev()) {
+            InnsendingProducer(
+                KafkaProducer(
+                    createKafkaProducerConfig(producerName = "api-innsending-producer"),
+                    StringSerializer(),
+                    InnsendingSerializer(),
+                ),
+            )
+        } else {
+            IngenInnsendingProducer()
+        }
 
     val bakgrunnsjobbService =
         LeaderElectedBakgrunnsjobbService(
@@ -118,33 +123,33 @@ fun Application.configureKafkaConsumers(
     services: Services,
     repositories: Repositories,
 ) {
+    val inntektsmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("im"))
+    launch(Dispatchers.Default) {
+        startKafkaConsumer(
+            getProperty("kafkaConsumer.inntektsmelding.topic"),
+            inntektsmeldingKafkaConsumer,
+            InntektsmeldingTolker(
+                services.inntektsmeldingService,
+                repositories.mottakRepository,
+            ),
+        )
+    }
+
+    val forespoerselKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("fsp"))
+    launch(Dispatchers.Default) {
+        startKafkaConsumer(
+            getProperty("kafkaConsumer.forespoersel.topic"),
+            forespoerselKafkaConsumer,
+            ForespoerselTolker(
+                repositories.forespoerselRepository,
+                repositories.mottakRepository,
+                services.dialogportenService,
+            ),
+        )
+    }
+
     // Ta bare imot dev kafka meldinger da repo er i testfase
     if (isLocal() || isDev()) {
-        val inntektsmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("im"))
-        launch(Dispatchers.Default) {
-            startKafkaConsumer(
-                getProperty("kafkaConsumer.inntektsmelding.topic"),
-                inntektsmeldingKafkaConsumer,
-                InntektsmeldingTolker(
-                    services.inntektsmeldingService,
-                    repositories.mottakRepository,
-                ),
-            )
-        }
-
-        val forespoerselKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("fsp"))
-        launch(Dispatchers.Default) {
-            startKafkaConsumer(
-                getProperty("kafkaConsumer.forespoersel.topic"),
-                forespoerselKafkaConsumer,
-                ForespoerselTolker(
-                    repositories.forespoerselRepository,
-                    repositories.mottakRepository,
-                    services.dialogportenService,
-                ),
-            )
-        }
-
         val sykmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("sm"))
         launch(Dispatchers.Default) {
             startKafkaConsumer(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
@@ -123,33 +123,33 @@ fun Application.configureKafkaConsumers(
     services: Services,
     repositories: Repositories,
 ) {
-    val inntektsmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("im"))
-    launch(Dispatchers.Default) {
-        startKafkaConsumer(
-            getProperty("kafkaConsumer.inntektsmelding.topic"),
-            inntektsmeldingKafkaConsumer,
-            InntektsmeldingTolker(
-                services.inntektsmeldingService,
-                repositories.mottakRepository,
-            ),
-        )
-    }
-
-    val forespoerselKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("fsp"))
-    launch(Dispatchers.Default) {
-        startKafkaConsumer(
-            getProperty("kafkaConsumer.forespoersel.topic"),
-            forespoerselKafkaConsumer,
-            ForespoerselTolker(
-                repositories.forespoerselRepository,
-                repositories.mottakRepository,
-                services.dialogportenService,
-            ),
-        )
-    }
-
     // Ta bare imot dev kafka meldinger da repo er i testfase
     if (isLocal() || isDev()) {
+        val inntektsmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("im"))
+        launch(Dispatchers.Default) {
+            startKafkaConsumer(
+                getProperty("kafkaConsumer.inntektsmelding.topic"),
+                inntektsmeldingKafkaConsumer,
+                InntektsmeldingTolker(
+                    services.inntektsmeldingService,
+                    repositories.mottakRepository,
+                ),
+            )
+        }
+
+        val forespoerselKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("fsp"))
+        launch(Dispatchers.Default) {
+            startKafkaConsumer(
+                getProperty("kafkaConsumer.forespoersel.topic"),
+                forespoerselKafkaConsumer,
+                ForespoerselTolker(
+                    repositories.forespoerselRepository,
+                    repositories.mottakRepository,
+                    services.dialogportenService,
+                ),
+            )
+        }
+
         val sykmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("sm"))
         launch(Dispatchers.Default) {
             startKafkaConsumer(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingService.kt
@@ -5,17 +5,15 @@ import no.nav.helsearbeidsgiver.bakgrunnsjobb.LeaderElectedBakgrunnsjobbService
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.Innsending
 import no.nav.helsearbeidsgiver.kafka.innsending.InnsendingKafka
 import no.nav.helsearbeidsgiver.kafka.innsending.InnsendingKafka.toJson
-import no.nav.helsearbeidsgiver.kafka.innsending.InnsendingProducer
+import no.nav.helsearbeidsgiver.kafka.innsending.InnsendingProducerI
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateTimeSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import no.nav.helsearbeidsgiver.utils.json.toPretty
-import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.time.LocalDateTime
 import java.util.UUID
 
 class InnsendingService(
-    private val innsendingProducer: InnsendingProducer,
+    private val innsendingProducer: InnsendingProducerI,
     private val bakgrunnsjobbService: LeaderElectedBakgrunnsjobbService,
 ) {
     fun lagreBakgrunsjobbInnsending(innsending: Innsending) {
@@ -29,18 +27,16 @@ class InnsendingService(
         val mottatt = LocalDateTime.now()
         val kontekstId = UUID.randomUUID()
 
-        val publisert =
-            innsendingProducer
-                .send(
-                    InnsendingKafka.Key.EVENT_NAME to InnsendingKafka.EventName.API_INNSENDING_STARTET.toJson(),
-                    InnsendingKafka.Key.KONTEKST_ID to kontekstId.toJson(UuidSerializer),
-                    InnsendingKafka.Key.DATA to
-                        mapOf(
-                            InnsendingKafka.Key.INNSENDING to innsending.toJson(Innsending.serializer()),
-                            InnsendingKafka.Key.MOTTATT to mottatt.toJson(LocalDateTimeSerializer),
-                        ).toJson(),
-                ).getOrThrow()
-        sikkerLogger().info("Publiserte melding om innsendt skjema:\n${publisert.toPretty()}")
+        innsendingProducer
+            .send(
+                InnsendingKafka.Key.EVENT_NAME to InnsendingKafka.EventName.API_INNSENDING_STARTET.toJson(),
+                InnsendingKafka.Key.KONTEKST_ID to kontekstId.toJson(UuidSerializer),
+                InnsendingKafka.Key.DATA to
+                    mapOf(
+                        InnsendingKafka.Key.INNSENDING to innsending.toJson(Innsending.serializer()),
+                        InnsendingKafka.Key.MOTTATT to mottatt.toJson(LocalDateTimeSerializer),
+                    ).toJson(),
+            )
         return Pair(kontekstId, mottatt)
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/innsending/InnsendingProducer.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/innsending/InnsendingProducer.kt
@@ -4,19 +4,47 @@ import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.Env.getProperty
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.json.toPretty
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 
-class InnsendingProducer(
-    private val kafkaProducer: KafkaProducer<String, JsonElement>,
-) {
+interface InnsendingProducerI {
+    fun send(vararg message: Pair<InnsendingKafka.Key, JsonElement>): Result<JsonElement>
+}
+
+class IngenInnsendingProducer : InnsendingProducerI {
     private val topic = getProperty("kafkaProducer.innsending.topic")
 
-    fun send(vararg message: Pair<InnsendingKafka.Key, JsonElement>): Result<JsonElement> =
+    override fun send(vararg message: Pair<InnsendingKafka.Key, JsonElement>): Result<JsonElement> =
+        Result
+            .success("".toJson())
+            .also { sikkerLogger().info("Publiserer ingen melding om innsendt skjema til $topic.") }
+}
+
+class InnsendingProducer(
+    private val kafkaProducer: KafkaProducer<String, JsonElement>,
+) : InnsendingProducerI {
+    private val topic = getProperty("kafkaProducer.innsending.topic")
+
+    override fun send(vararg message: Pair<InnsendingKafka.Key, JsonElement>): Result<JsonElement> =
         message
             .toMap()
             .toJson()
             .let(::send)
+            .onSuccess {
+                sikkerLogger().info("Publiserte melding om innsendt skjema på topic $topic:\n${it.toPretty()}")
+            }.onFailure {
+                throw it.also {
+                    sikkerLogger().error(
+                        "Klarte ikke publisere melding om innsendt skjema på topic $topic:\n${
+                            message
+                                .toMap()
+                                .toJson().toPretty()
+                        }",
+                    )
+                }
+            }
 
     private fun Map<InnsendingKafka.Key, JsonElement>.toJson(): JsonElement =
         toJson(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingServiceTest.kt
@@ -3,8 +3,8 @@ package no.nav.helsearbeidsgiver.innsending
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import no.nav.hag.utils.bakgrunnsjobb.BakgrunnsjobbRepository
 import no.nav.helsearbeidsgiver.bakgrunnsjobb.InnsendingProcessor
 import no.nav.helsearbeidsgiver.bakgrunnsjobb.LeaderElectedBakgrunnsjobbService
@@ -32,10 +32,8 @@ class InnsendingServiceTest {
     init {
         every {
             innsendingProducer.send(*anyVararg<Pair<InnsendingKafka.Key, JsonElement>>())
-        } returns toResult("".toJson(String.serializer()))
+        } returns JsonNull
     }
-
-    private fun toResult(toJson: JsonElement): Result<JsonElement> = runCatching { toJson }
 
     @Test
     fun `sendInn kaller innsendingproducer sin send-metode med forventede nøkler og verdier`() {


### PR DESCRIPTION
**Bakgrunn**
Vi ønsker å forsikre oss at vi ikke forsøker å sende API-mottatte IMer videre til Simba i produksjon før vi er klare for dette.

**Løsning**
Lag en `IngenInnsendingProducer`, som vi bruker istedenfor `InnsendingProducer` i produksjon.