### PR TITLE
Konsumer inntektsmeldinger og forespørsler i produksjon

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
@@ -123,33 +123,33 @@ fun Application.configureKafkaConsumers(
     services: Services,
     repositories: Repositories,
 ) {
-    // Ta bare imot dev kafka meldinger da repo er i testfase
+    val inntektsmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("im"))
+    launch(Dispatchers.Default) {
+        startKafkaConsumer(
+            getProperty("kafkaConsumer.inntektsmelding.topic"),
+            inntektsmeldingKafkaConsumer,
+            InntektsmeldingTolker(
+                services.inntektsmeldingService,
+                repositories.mottakRepository,
+            ),
+        )
+    }
+
+    val forespoerselKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("fsp"))
+    launch(Dispatchers.Default) {
+        startKafkaConsumer(
+            getProperty("kafkaConsumer.forespoersel.topic"),
+            forespoerselKafkaConsumer,
+            ForespoerselTolker(
+                repositories.forespoerselRepository,
+                repositories.mottakRepository,
+                services.dialogportenService,
+            ),
+        )
+    }
+
+    // Ta bare imot dev kafka sykmeldinger da repo er i testfase
     if (isLocal() || isDev()) {
-        val inntektsmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("im"))
-        launch(Dispatchers.Default) {
-            startKafkaConsumer(
-                getProperty("kafkaConsumer.inntektsmelding.topic"),
-                inntektsmeldingKafkaConsumer,
-                InntektsmeldingTolker(
-                    services.inntektsmeldingService,
-                    repositories.mottakRepository,
-                ),
-            )
-        }
-
-        val forespoerselKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("fsp"))
-        launch(Dispatchers.Default) {
-            startKafkaConsumer(
-                getProperty("kafkaConsumer.forespoersel.topic"),
-                forespoerselKafkaConsumer,
-                ForespoerselTolker(
-                    repositories.forespoerselRepository,
-                    repositories.mottakRepository,
-                    services.dialogportenService,
-                ),
-            )
-        }
-
         val sykmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("sm"))
         launch(Dispatchers.Default) {
             startKafkaConsumer(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
@@ -148,7 +148,7 @@ fun Application.configureKafkaConsumers(
         )
     }
 
-    // Ta bare imot dev kafka sykmeldinger da repo er i testfase
+    // Ta bare imot sykmeldinger i dev inntil videre
     if (isLocal() || isDev()) {
         val sykmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("sm"))
         launch(Dispatchers.Default) {


### PR DESCRIPTION
**Bakgrunn**
Vi trengte å gjøre en opprydning i datamodellene våre, så for å unngå for mye søl underveis stoppet vi konsumentene for inntektsmeldinger og forespørsler i produksjon.

**Løsning**
Skru på igjen konsumenter for inntektsmeldinger og forespørsler i produksjon.