### PR TITLE
inkluder egenmeldingsdager i sykmelding

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiver.kt
@@ -26,7 +26,7 @@ data class SykmeldingArbeidsgiver(
     val sykmeldingId: String,
     @field:Schema(description = "Dato og tid for når sykmeldingen ble mottatt hos NAV")
     val mottattidspunkt: LocalDateTime,
-    val egenmeldingsdager: List<LocalDate>,
+    val egenmeldingsdager: Set<LocalDate>,
 )
 
 @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiver.kt
@@ -26,6 +26,7 @@ data class SykmeldingArbeidsgiver(
     val sykmeldingId: String,
     @field:Schema(description = "Dato og tid for når sykmeldingen ble mottatt hos NAV")
     val mottattidspunkt: LocalDateTime,
+    val egenmeldingsdager: Egenmeldingsdager? = null,
 )
 
 @Serializable
@@ -47,7 +48,6 @@ data class Sykmelding(
     val meldingTilArbeidsgiver: String? = null,
     val kontaktMedPasient: KontaktMedPasient,
     val behandler: Behandler,
-    val egenmeldingsdager: Egenmeldingsdager? = null,
 )
 
 @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiver.kt
@@ -26,7 +26,7 @@ data class SykmeldingArbeidsgiver(
     val sykmeldingId: String,
     @field:Schema(description = "Dato og tid for når sykmeldingen ble mottatt hos NAV")
     val mottattidspunkt: LocalDateTime,
-    val egenmeldingsdager: Egenmeldingsdager? = null,
+    val egenmeldingsdager: List<LocalDate>,
 )
 
 @Serializable
@@ -162,10 +162,4 @@ data class Behandler(
 data class Arbeidsgiver(
     @field:Schema(description = "Navn på arbeidsgiver slik det fremkommer av sykmeldingen. Dette navnet fylles ut av lege.")
     val navn: String? = null,
-)
-
-@Serializable
-@Schema(description = "Egenmeldingsdager")
-data class Egenmeldingsdager(
-    val dager: List<LocalDate>?,
 )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
@@ -12,7 +12,7 @@ import no.nav.helsearbeidsgiver.sykmelding.SendSykmeldingAivenKafkaMessage
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
-import no.nav.helsearbeidsgiver.utils.json.serializer.list
+import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -33,12 +33,12 @@ fun tilSykmeldingArbeidsgiver(
         egenmeldingsdager = sykmeldingDTO.event.sporsmals.tilEgenmeldingsdager(),
     )
 
-private fun List<SykmeldingStatusKafkaEventDTO.SporsmalOgSvarDTO>?.tilEgenmeldingsdager(): List<LocalDate> =
+private fun List<SykmeldingStatusKafkaEventDTO.SporsmalOgSvarDTO>?.tilEgenmeldingsdager(): Set<LocalDate> =
     this
         ?.find { it.shortName == SykmeldingStatusKafkaEventDTO.ShortNameDTO.EGENMELDINGSDAGER }
         ?.svar
-        ?.fromJson(LocalDateSerializer.list())
-        ?: emptyList()
+        ?.fromJson(LocalDateSerializer.set())
+        ?: emptySet()
 
 private fun ArbeidsgiverSykmeldingKafka.tilSykmelding(person: Person): Sykmelding =
     Sykmelding(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
@@ -3,7 +3,6 @@
 package no.nav.helsearbeidsgiver.sykmelding.model
 
 import kotlinx.serialization.UseSerializers
-import kotlinx.serialization.json.Json
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.ArbeidsgiverAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.BehandlerAGDTO

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
@@ -35,7 +35,8 @@ fun tilSykmeldingArbeidsgiver(
 private fun List<SykmeldingStatusKafkaEventDTO.SporsmalOgSvarDTO>?.tilEgenmeldingsdager(): Egenmeldingsdager? =
     this
         ?.find { it.shortName == SykmeldingStatusKafkaEventDTO.ShortNameDTO.EGENMELDINGSDAGER }
-        ?.let { Json.decodeFromString<List<@kotlinx.serialization.Serializable LocalDate>>(it.svar) }
+        ?.let { Json.decodeFromString<List<String>>(it.svar) }
+        ?.map { LocalDate.parse(it) }
         ?.let { Egenmeldingsdager(it) }
 
 private fun ArbeidsgiverSykmeldingKafka.tilSykmelding(person: Person): Sykmelding =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
@@ -11,7 +11,9 @@ import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.PrognoseA
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.SykmeldingsperiodeAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.SendSykmeldingAivenKafkaMessage
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO
+import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
+import no.nav.helsearbeidsgiver.utils.json.serializer.list
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -32,12 +34,12 @@ fun tilSykmeldingArbeidsgiver(
         egenmeldingsdager = sykmeldingDTO.event.sporsmals.tilEgenmeldingsdager(),
     )
 
-private fun List<SykmeldingStatusKafkaEventDTO.SporsmalOgSvarDTO>?.tilEgenmeldingsdager(): Egenmeldingsdager? =
+private fun List<SykmeldingStatusKafkaEventDTO.SporsmalOgSvarDTO>?.tilEgenmeldingsdager(): List<LocalDate> =
     this
         ?.find { it.shortName == SykmeldingStatusKafkaEventDTO.ShortNameDTO.EGENMELDINGSDAGER }
-        ?.let { Json.decodeFromString<List<String>>(it.svar) }
-        ?.map { LocalDate.parse(it) }
-        ?.let { Egenmeldingsdager(it) }
+        ?.svar
+        ?.fromJson(LocalDateSerializer.list())
+        ?: emptyList()
 
 private fun ArbeidsgiverSykmeldingKafka.tilSykmelding(person: Person): Sykmelding =
     Sykmelding(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapperTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapperTest.kt
@@ -27,12 +27,10 @@ class SykmeldingArbeidsgiverMapperTest {
             )
 
         sykmeldingArbeidsgiver.egenmeldingsdager shouldBe
-            Egenmeldingsdager(
-                listOf(
-                    LocalDate.of(2025, 3, 27),
-                    LocalDate.of(2025, 3, 29),
-                    LocalDate.of(2025, 3, 26),
-                ),
+            listOf(
+                LocalDate.of(2025, 3, 27),
+                LocalDate.of(2025, 3, 29),
+                LocalDate.of(2025, 3, 26),
             )
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapperTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapperTest.kt
@@ -27,7 +27,7 @@ class SykmeldingArbeidsgiverMapperTest {
             )
 
         sykmeldingArbeidsgiver.egenmeldingsdager shouldBe
-            listOf(
+            setOf(
                 LocalDate.of(2025, 3, 27),
                 LocalDate.of(2025, 3, 29),
                 LocalDate.of(2025, 3, 26),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapperTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapperTest.kt
@@ -1,0 +1,38 @@
+package no.nav.helsearbeidsgiver.sykmelding.model
+
+import io.kotest.matchers.shouldBe
+import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO
+import no.nav.helsearbeidsgiver.sykmelding.mockHentPersonFraPDL
+import no.nav.helsearbeidsgiver.utils.TestData.sykmeldingMock
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class SykmeldingArbeidsgiverMapperTest {
+    @Test
+    fun `tilEgenmeldingsdager leser SporsmalOgSvarDTO riktig`() {
+        val sykmeldingMock = sykmeldingMock()
+
+        val egenmeldingSvar =
+            SykmeldingStatusKafkaEventDTO.SporsmalOgSvarDTO(
+                tekst = "abc",
+                shortName = SykmeldingStatusKafkaEventDTO.ShortNameDTO.EGENMELDINGSDAGER,
+                svartype = SykmeldingStatusKafkaEventDTO.SvartypeDTO.DAGER,
+                svar = "[\"2025-03-27\",\"2025-03-29\",\"2025-03-26\"]",
+            )
+
+        val sykmeldingArbeidsgiver =
+            tilSykmeldingArbeidsgiver(
+                sykmeldingDTO = sykmeldingMock.copy(event = sykmeldingMock.event.copy(sporsmals = listOf(egenmeldingSvar))),
+                person = mockHentPersonFraPDL(sykmeldingMock.kafkaMetadata.fnr),
+            )
+
+        sykmeldingArbeidsgiver.egenmeldingsdager shouldBe
+            Egenmeldingsdager(
+                listOf(
+                    LocalDate.of(2025, 3, 27),
+                    LocalDate.of(2025, 3, 29),
+                    LocalDate.of(2025, 3, 26),
+                ),
+            )
+    }
+}


### PR DESCRIPTION
Før har vi bare satt `egenmeldinger = null`. Nå som vi har nødvendig data i databasen kan vi inkludere egenmeldingsdager.

Her er et eksempel på hvordan meldingen ser ut i Kafka json om sykmeldt registrer egenmeldingsdager på nav nettsiden:
```json
"sporsmals": [
    {
        "tekst": "Jeg er sykmeldt som",
        "shortName": "ARBEIDSSITUASJON",
        "svartype": "ARBEIDSSITUASJON",
        "svar": "ARBEIDSTAKER"
    },
    {
        "tekst": "Velg dagene du brukte egenmelding",
        "shortName": "EGENMELDINGSDAGER",
        "svartype": "DAGER",
        "svar": "[\"2025-03-27\",\"2025-03-29\",\"2025-03-26\"]"
    }
],
```