### PR TITLE
La workflow vente på foregående for deploy til dev

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,9 @@ on:
       - main
       - 'dev/**'
 
+concurrency:
+  group: deploy-dev
+
 env:
   ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Gjør at to deploy til dev ikke spenner bein på hverandre.

Se mer på https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency.