### PR TITLE
Bytt til hag perioder for egenmeldingsdager i sykmelding

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -35,7 +35,7 @@ data class Sykmelding(
     @field:Schema(description = "Arbeidsgiver oppgitt av behandler")
     val arbeidsgiver: Arbeidsgiver? = null,
     @field:Schema(description = "Sammenhengende, ikke overlappende perioder for denne sykmeldingen")
-    val perioder: List<PeriodeSykmelding>? = null,
+    val perioder: List<SykmeldingPeriode>? = null,
     @field:Schema(description = "Prognose")
     val prognose: Prognose? = null,
     @field:Schema(description = "Innspill til tiltak som kan bedre arbeidsevnen")
@@ -48,7 +48,7 @@ data class Sykmelding(
 
 @Serializable
 @Schema(description = "Periode")
-data class PeriodeSykmelding(
+data class SykmeldingPeriode(
     @field:Schema(description = "Sykmeldingsperiodens fra og med dato")
     val fom: LocalDate,
     @field:Schema(description = "Sykmeldingsperiodens til og med dato")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -8,6 +8,7 @@ package no.nav.helsearbeidsgiver.sykmelding.model
 import io.swagger.v3.oas.annotations.media.Schema
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateTimeSerializer
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
@@ -26,7 +27,7 @@ data class Sykmelding(
     val sykmeldingId: String,
     @field:Schema(description = "Dato og tid for når sykmeldingen ble mottatt hos NAV")
     val mottattidspunkt: LocalDateTime,
-    val egenmeldingsdager: Set<LocalDate>,
+    val egenmeldingsdager: Set<Periode>,
     @field:Schema(description = "Når startet syketilfellet")
     val syketilfelleFom: LocalDate?,
     val sykmeldtFnr: Fnr,
@@ -34,7 +35,7 @@ data class Sykmelding(
     @field:Schema(description = "Arbeidsgiver oppgitt av behandler")
     val arbeidsgiver: Arbeidsgiver? = null,
     @field:Schema(description = "Sammenhengende, ikke overlappende perioder for denne sykmeldingen")
-    val perioder: List<Periode>? = null,
+    val perioder: List<PeriodeSykmelding>? = null,
     @field:Schema(description = "Prognose")
     val prognose: Prognose? = null,
     @field:Schema(description = "Innspill til tiltak som kan bedre arbeidsevnen")
@@ -47,7 +48,7 @@ data class Sykmelding(
 
 @Serializable
 @Schema(description = "Periode")
-data class Periode(
+data class PeriodeSykmelding(
     @field:Schema(description = "Sykmeldingsperiodens fra og med dato")
     val fom: LocalDate,
     @field:Schema(description = "Sykmeldingsperiodens til og med dato")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
@@ -3,6 +3,7 @@
 package no.nav.helsearbeidsgiver.sykmelding.model
 
 import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.ArbeidsgiverAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.BehandlerAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.PrognoseAGDTO
@@ -13,9 +14,9 @@ import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO.Sporsma
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.set
+import no.nav.helsearbeidsgiver.utils.tilPerioder
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
-import java.time.LocalDate
 import java.time.OffsetDateTime
 
 fun SykmeldingDTO.tilSykmeldingArbeidsgiver(person: Person): Sykmelding {
@@ -40,11 +41,12 @@ fun SykmeldingDTO.tilSykmeldingArbeidsgiver(person: Person): Sykmelding {
     )
 }
 
-private fun List<SporsmalOgSvarDTO>?.tilEgenmeldingsdager(): Set<LocalDate> =
+private fun List<SporsmalOgSvarDTO>?.tilEgenmeldingsdager(): Set<Periode> =
     this
         ?.find { it.shortName == ShortNameDTO.EGENMELDINGSDAGER }
         ?.svar
         ?.fromJson(LocalDateSerializer.set())
+        ?.tilPerioder()
         ?: emptySet()
 
 private fun String.tilTiltak(): Tiltak = Tiltak(tiltakArbeidsplassen = this)
@@ -55,9 +57,9 @@ private fun PrognoseAGDTO.getPrognose(): Prognose =
         beskrivHensynArbeidsplassen = this.hensynArbeidsplassen,
     )
 
-private fun List<SykmeldingsperiodeAGDTO>.tilPerioderAG(): List<Periode> =
+private fun List<SykmeldingsperiodeAGDTO>.tilPerioderAG(): List<PeriodeSykmelding> =
     map {
-        Periode(
+        PeriodeSykmelding(
             fom = it.fom,
             tom = it.tom,
             aktivitet = it.tilAktivitet(),

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
@@ -57,9 +57,9 @@ private fun PrognoseAGDTO.getPrognose(): Prognose =
         beskrivHensynArbeidsplassen = this.hensynArbeidsplassen,
     )
 
-private fun List<SykmeldingsperiodeAGDTO>.tilPerioderAG(): List<PeriodeSykmelding> =
+private fun List<SykmeldingsperiodeAGDTO>.tilPerioderAG(): List<SykmeldingPeriode> =
     map {
-        PeriodeSykmelding(
+        SykmeldingPeriode(
             fom = it.fom,
             tom = it.tom,
             aktivitet = it.tilAktivitet(),

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/SykmeldingUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/SykmeldingUtils.kt
@@ -1,0 +1,22 @@
+package no.nav.helsearbeidsgiver.utils
+
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
+import java.time.LocalDate
+
+fun Set<LocalDate>.tilPerioder(): Set<Periode> {
+    if (isEmpty()) return emptySet()
+    val sorterteDatoer = sorted().toSet()
+
+    return buildSet {
+        var periodeStart = sorterteDatoer.first()
+
+        sorterteDatoer.zipWithNext().forEach { (dato, nesteDato) ->
+            if (nesteDato != dato.plusDays(1)) {
+                add(Periode(fom = periodeStart, tom = dato))
+                periodeStart = nesteDato
+            }
+        }
+
+        add(Periode(periodeStart, sorterteDatoer.last()))
+    }
+}

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapperTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapperTest.kt
@@ -1,6 +1,7 @@
 package no.nav.helsearbeidsgiver.sykmelding.model
 
 import io.kotest.matchers.shouldBe
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingDTO
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO
 import no.nav.helsearbeidsgiver.sykmelding.toMockSykmeldingArbeidsgiver
@@ -35,9 +36,14 @@ class SykmeldingMapperTest {
 
         sykmeldingArbeidsgiver.egenmeldingsdager shouldBe
             setOf(
-                LocalDate.of(2025, 3, 27),
-                LocalDate.of(2025, 3, 29),
-                LocalDate.of(2025, 3, 26),
+                Periode(
+                    fom = LocalDate.of(2025, 3, 26),
+                    tom = LocalDate.of(2025, 3, 27),
+                ),
+                Periode(
+                    fom = LocalDate.of(2025, 3, 29),
+                    tom = LocalDate.of(2025, 3, 29),
+                ),
             )
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingUtilsTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingUtilsTest.kt
@@ -1,0 +1,40 @@
+package no.nav.helsearbeidsgiver.sykmelding.model
+
+import io.kotest.matchers.shouldBe
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
+import no.nav.helsearbeidsgiver.utils.tilPerioder
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class SykmeldingUtilsTest {
+    @Test
+    fun `List av LocalDate tilPerioder konverterer riktig`() {
+        mockLocalDates(1, 2, 4).tilPerioder() shouldBe
+            mockPerioder(1 to 2, 4 to 4)
+    }
+
+    @Test
+    fun `List av LocalDate tilPerioder ignorerer duplikater`() {
+        mockLocalDates(1, 1, 1, 5, 6, 6, 7).tilPerioder() shouldBe
+            mockPerioder(1 to 1, 5 to 7)
+    }
+
+    @Test
+    fun `List av LocalDate tilPerioder ignorer orde av datoer`() {
+        mockLocalDates(4, 3, 1).tilPerioder() shouldBe
+            mockPerioder(1 to 1, 3 to 4)
+    }
+
+    @Test
+    fun `List av LocalDate tilPerioder uten dager returnerer tom set`() {
+        emptySet<LocalDate>().tilPerioder() shouldBe emptySet()
+    }
+}
+
+fun mockLocalDates(vararg dag: Int): Set<LocalDate> = dag.asList().map { it.tilLocalDate() }.toSet()
+
+fun mockPerioder(vararg pair: Pair<Int, Int>): Set<Periode> = pair.asList().map { it.tilMockPeriode() }.toSet()
+
+fun Pair<Int, Int>.tilMockPeriode(): Periode = Periode(fom = first.tilLocalDate(), tom = second.tilLocalDate())
+
+fun Int.tilLocalDate(): LocalDate = LocalDate.of(2023, 5, this)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingUtilsTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingUtilsTest.kt
@@ -20,7 +20,7 @@ class SykmeldingUtilsTest {
     }
 
     @Test
-    fun `List av LocalDate tilPerioder ignorer orde av datoer`() {
+    fun `List av LocalDate tilPerioder ignorer rekkefølge av datoer`() {
         mockLocalDates(4, 3, 1).tilPerioder() shouldBe
             mockPerioder(1 to 1, 3 to 4)
     }


### PR DESCRIPTION
Denne PRen bytter egenmeldingsdager i sykmelding API fra en liste av `LocalDate` til en liste av `Periode` 

(bruker `helsearbeidsgiver.domene.inntektsmelding.v1.Periode`)

Testet at det funker i dev for sykmelding med ID: `0a380626-8856-4a8a-9960-97d00cb1041e`

**Motatt data i kafka melding:**
```json
 "svar": "[\"2025-03-29\",\"2025-03-30\",\"2025-03-31\"]",
```
**Vår sykmelding API respons:**
```json
"egenmeldingsdager": [
    {
      "fom": "2025-03-29",
      "tom": "2025-03-31"
    }
  ]
```