### PR TITLE
Forenkle behandler i sykmelding

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -42,8 +42,8 @@ data class Sykmelding(
     @field:Schema(description = "Øvrige kommentarer: kontakt mellom lege/arbeidsgiver - melding fra behandler")
     val meldingTilArbeidsgiver: String? = null,
     val kontaktMedPasient: KontaktMedPasient,
-    val behandlerNavn: Navn?,
-    val behandlerTlf: String?,
+    val behandlerNavn: Navn,
+    val behandlerTlf: String,
 )
 
 @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -42,7 +42,8 @@ data class Sykmelding(
     @field:Schema(description = "Øvrige kommentarer: kontakt mellom lege/arbeidsgiver - melding fra behandler")
     val meldingTilArbeidsgiver: String? = null,
     val kontaktMedPasient: KontaktMedPasient,
-    val behandler: Behandler,
+    val behandlerNavn: Navn?,
+    val behandlerTlf: String?,
 )
 
 @Serializable
@@ -132,15 +133,6 @@ data class Navn(
     val mellomnavn: String? = null,
     @field:Schema(description = "Fornavn")
     val fornavn: String,
-)
-
-@Serializable
-@Schema(description = "Behandler")
-data class Behandler(
-    @field:Schema(description = "Behandlers navn")
-    val navn: Navn,
-    @field:Schema(description = "Behandlers kontaktinformasjon")
-    val telefonnummer: String,
 )
 
 @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
@@ -30,7 +30,7 @@ fun SykmeldingDTO.tilSykmeldingArbeidsgiver(person: Person): Sykmelding {
         orgnr = event.arbeidsgiver.orgnummer.let { Orgnr(it) },
         egenmeldingsdager = event.sporsmals.tilEgenmeldingsdager(),
         arbeidsgiver = sykmelding.arbeidsgiver.tilArbeidsgiver(),
-        behandlerNavn = sykmelding.behandler?.tilNavn(),
+        behandlerNavn = sykmelding.behandler.tilNavn(),
         behandlerTlf = sykmelding.behandler?.tlf.tolkTelefonNr(),
         kontaktMedPasient = sykmelding.behandletTidspunkt.tilKontaktMedPasient(),
         meldingTilArbeidsgiver = sykmelding.meldingTilArbeidsgiver,
@@ -102,11 +102,11 @@ fun String?.tolkTelefonNr(): String =
         ?.removePrefix("fax:")
         ?: ""
 
-private fun BehandlerAGDTO.tilNavn(): Navn =
+private fun BehandlerAGDTO?.tilNavn(): Navn =
     Navn(
-        fornavn = this.fornavn,
-        etternavn = this.etternavn,
-        mellomnavn = this.mellomnavn,
+        fornavn = this?.fornavn ?: "",
+        etternavn = this?.etternavn ?: "",
+        mellomnavn = this?.mellomnavn ?: "",
     )
 
 private fun ArbeidsgiverAGDTO.tilArbeidsgiver(): Arbeidsgiver =


### PR DESCRIPTION
Sletter Behandler objekt i sykmelding

`behandler.navn -> navn`
`behandler.telefonnummer -> behandlerTlf`

Dette gjør formatet på variabler i sykmeldingen mer uniform og lik inntektsmeldingen som har sykmeldtNavn og sykmeldtTlf