### PR TITLE
Forenklet sykmelding kode og gjør boolean ikke nullable

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -105,7 +105,7 @@ data class Arbeidsutsikter(
 @Schema(description = "Prognose")
 data class Prognose(
     @field:Schema(description = "Arbeidsfør etter denne perioden?")
-    val erArbeidsfoerEtterEndtPeriode: Boolean? = null,
+    val erArbeidsfoerEtterEndtPeriode: Boolean,
     @field:Schema(description = "Hvis arbeidsfør etter denne perioden: Beskriv eventuelle hensyn som må tas på arbeidsplassen.")
     val beskrivHensynArbeidsplassen: String? = null,
     @field:Schema(description = "Utsikter for arbeid")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -70,7 +70,7 @@ data class Aktivitet(
     @Schema(description = "Antall behandlingsdager per uke")
     val antallBehandlingsdagerUke: Int?,
     @Schema(description = "Har reisetilskudd")
-    val harReisetilskudd: Boolean?,
+    val harReisetilskudd: Boolean,
 )
 
 @Serializable
@@ -79,14 +79,14 @@ data class GradertSykmelding(
     @field:Schema(description = "Angitt sykemeldingsgrad")
     val sykmeldingsgrad: Int,
     @field:Schema(description = "Reisetilskudd ved gradert sykmelding")
-    val harReisetilskudd: Boolean? = null,
+    val harReisetilskudd: Boolean,
 )
 
 @Serializable
 @Schema(description = "Aktivitet ikke mulig")
 data class AktivitetIkkeMulig(
     @field:Schema(description = "Settes til true dersom arbeidsplassen mangler tilrettelegging")
-    val manglendeTilretteleggingPaaArbeidsplassen: Boolean? = null,
+    val manglendeTilretteleggingPaaArbeidsplassen: Boolean,
     @field:Schema(description = "Eventuell beskrivelse på hvorfor aktivitet ikke er mulig")
     val beskrivelse: String? = null,
 )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
@@ -8,8 +8,9 @@ import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.Arbeidsgi
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.BehandlerAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.PrognoseAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.SykmeldingsperiodeAGDTO
-import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.SykmeldingsperiodeAGDTO.AktivitetIkkeMuligAGDTO
+import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.SykmeldingsperiodeAGDTO.AktivitetIkkeMuligAGDTO.ArbeidsrelatertArsakDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.SykmeldingsperiodeAGDTO.AktivitetIkkeMuligAGDTO.ArbeidsrelatertArsakDTO.ArbeidsrelatertArsakTypeDTO.MANGLENDE_TILRETTELEGGING
+import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.SykmeldingsperiodeAGDTO.GradertDTO
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingDTO
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO.ShortNameDTO
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO.SporsmalOgSvarDTO
@@ -72,20 +73,19 @@ private fun List<SykmeldingsperiodeAGDTO>.tilPerioderAG(): List<SykmeldingPeriod
 private fun SykmeldingsperiodeAGDTO.tilAktivitet(): Aktivitet =
     Aktivitet(
         avventendeSykmelding = innspillTilArbeidsgiver,
-        gradertSykmelding = gradert?.let { GradertSykmelding(it.grad, it.reisetilskudd) },
-        aktivitetIkkeMulig = aktivitetIkkeMulig?.tilAktivitetIkkeMulig(),
-        harReisetilskudd = if (this.reisetilskudd) true else null,
+        gradertSykmelding = gradert?.tilGradertSykmelding(),
+        aktivitetIkkeMulig = aktivitetIkkeMulig?.arbeidsrelatertArsak?.tilAktivitetIkkeMulig(),
+        harReisetilskudd = reisetilskudd,
         antallBehandlingsdagerUke = behandlingsdager,
     )
 
-private fun AktivitetIkkeMuligAGDTO.tilAktivitetIkkeMulig(): AktivitetIkkeMulig =
+private fun ArbeidsrelatertArsakDTO.tilAktivitetIkkeMulig(): AktivitetIkkeMulig =
     AktivitetIkkeMulig(
-        manglendeTilretteleggingPaaArbeidsplassen = erMangledneTilrettelegging(this),
-        beskrivelse = this.arbeidsrelatertArsak?.beskrivelse,
+        manglendeTilretteleggingPaaArbeidsplassen = arsak.any { it == MANGLENDE_TILRETTELEGGING },
+        beskrivelse = beskrivelse,
     )
 
-private fun erMangledneTilrettelegging(aktivitetIkkeMulig: AktivitetIkkeMuligAGDTO): Boolean? =
-    aktivitetIkkeMulig.arbeidsrelatertArsak?.arsak?.any { it == MANGLENDE_TILRETTELEGGING }
+private fun GradertDTO.tilGradertSykmelding(): GradertSykmelding = GradertSykmelding(grad, reisetilskudd)
 
 private fun Person.tilNavn(): Navn =
     Navn(


### PR DESCRIPTION
Refaktorisert kode til å ikke bruke nullable boolean 

`periode[].aktivetet.gradertSykmelding.harReisetilskudd` ikke nullable i kafka meldingen

`prognose.erArbeidsfoerEtterEndtPeriode` ikke nullable i kafka meldingen

`periode[].aktivetet.harReisetilskudd` var true eller null, nå er den true eller false 

Disse endringen er nevnt i [migrasjon dokumentet](https://navno-my.sharepoint.com/:w:/g/personal/jesper_forrest_hustad_nav_no/EQIBJijr0LVFkoi7QK8vJO4B1B8AKNQuKDcG9m1frzR4fw?e=VfqhdG) 
(finnes i Slack `team-arbeidsgiver-internal > Bookmarks > Sykmelding migrasjon` )

Dette gjennomfører målet om å ikke bruke nullable boolean i sykmelding API.