### PR TITLE
Slett prognose.arbeidsutsiker da den aldri ble brukt

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -92,24 +92,12 @@ data class AktivitetIkkeMulig(
 )
 
 @Serializable
-@Schema(description = "Arbeidsutsikter")
-data class Arbeidsutsikter(
-    @field:Schema(description = "Gjelder de MED arbeidsgiver")
-    val harEgetArbeidPaaSikt: Boolean? = null,
-    @field:Schema(description = "Gjelder de UTEN arbeidsgiver")
-    val arbeidFom: String? = null,
-    val harAnnetArbeidPaaSikt: Boolean? = null,
-)
-
-@Serializable
 @Schema(description = "Prognose")
 data class Prognose(
     @field:Schema(description = "Arbeidsfør etter denne perioden?")
     val erArbeidsfoerEtterEndtPeriode: Boolean? = null,
     @field:Schema(description = "Hvis arbeidsfør etter denne perioden: Beskriv eventuelle hensyn som må tas på arbeidsplassen.")
     val beskrivHensynArbeidsplassen: String? = null,
-    @field:Schema(description = "Utsikter for arbeid")
-    val arbeidsutsikter: Arbeidsutsikter? = null,
 )
 
 @Serializable


### PR DESCRIPTION
Arbeidsutsikter er et objekt som aldri blir definert i syfosmaltinn, ser derfor ut til å være noe gammelt som man sluttet å støtte. 

`arbeidsutsikter` eksisterer ingen steder i syfosmaltinn main:
![image](https://github.com/user-attachments/assets/8e54efc4-e362-42c3-a972-097ef6b655f7)


Her er en [link til syfosmaltinn](https://github.com/navikt/syfosmaltinn/blob/02cfd410453ace0086b72bb028fc23d3bbba60e0/src/main/kotlin/no/nav/syfo/altinn/model/SykmeldingArbeidsgiverMapper.kt#L103-L113) der prognose objektet er definert for sykmeldingen der vi ser at arbeidsutsikter ikke er inkludert (XMLPorgnose inneholder arbeidsutsikter som nullable):

```kotlin
private fun getPrognose(prognose: PrognoseAGDTO?): XMLPrognose? {
      return when (prognose) {
          null -> null
          else -> {
              val xmlPrognose = ObjectFactory().createXMLPrognose()
              xmlPrognose.isErArbeidsfoerEtterEndtPeriode = prognose.arbeidsforEtterPeriode
              xmlPrognose.beskrivHensynArbeidsplassen = prognose.hensynArbeidsplassen
              xmlPrognose
          }
      }
  }
```