### PR TITLE
bruk ekte PDL navn istedenfor mock verdi i Sykmelding response

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingService.kt
@@ -28,9 +28,7 @@ class SykmeldingService(
 
             sikkerLogger().info("Hentet sykmelding $id for orgnr: $orgnr")
 
-            val person = mockHentPersonFraPDL(sykmeldingDTO.fnr) // TODO: Bruk ekte PDL
-
-            val sykmeldingArbeidsgiver = sykmeldingDTO.tilSykmeldingArbeidsgiver(person)
+            val sykmeldingArbeidsgiver = sykmeldingDTO.tilSykmeldingArbeidsgiver()
 
             return sykmeldingArbeidsgiver
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingService.kt
@@ -28,9 +28,7 @@ class SykmeldingService(
 
             sikkerLogger().info("Hentet sykmelding $id for orgnr: $orgnr")
 
-            val sykmeldingArbeidsgiver = sykmeldingDTO.tilSykmeldingArbeidsgiver()
-
-            return sykmeldingArbeidsgiver
+            return sykmeldingDTO.tilSykmeldingArbeidsgiver()
         } catch (e: Exception) {
             throw RuntimeException("Feil ved henting av sykmelding $id orgnr: $orgnr", e)
         }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -31,7 +31,7 @@ data class Sykmelding(
     @field:Schema(description = "Når startet syketilfellet")
     val syketilfelleFom: LocalDate?,
     val sykmeldtFnr: Fnr,
-    val sykmeldtNavn: Navn,
+    val sykmeldtNavn: String,
     @field:Schema(description = "Arbeidsgiver oppgitt av behandler")
     val arbeidsgiver: Arbeidsgiver? = null,
     @field:Schema(description = "Sammenhengende, ikke overlappende perioder for denne sykmeldingen")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingArbeidsgiverMapper.kt
@@ -22,9 +22,10 @@ import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.time.OffsetDateTime
 
-fun SykmeldingDTO.tilSykmeldingArbeidsgiver(person: Person): Sykmelding {
+fun SykmeldingDTO.tilSykmeldingArbeidsgiver(): Sykmelding {
     val sykmelding = sendSykmeldingAivenKafkaMessage.sykmelding
     val event = sendSykmeldingAivenKafkaMessage.event
+    val kafkaMetadata = sendSykmeldingAivenKafkaMessage.kafkaMetadata
     return Sykmelding(
         orgnrHovedenhet = event.arbeidsgiver.juridiskOrgnummer?.let { Orgnr(it) },
         mottattidspunkt = sykmelding.mottattTidspunkt.toLocalDateTime(),
@@ -36,8 +37,8 @@ fun SykmeldingDTO.tilSykmeldingArbeidsgiver(person: Person): Sykmelding {
         behandlerTlf = sykmelding.behandler?.tlf.tolkTelefonNr(),
         kontaktMedPasient = sykmelding.behandletTidspunkt.tilKontaktMedPasient(),
         meldingTilArbeidsgiver = sykmelding.meldingTilArbeidsgiver,
-        sykmeldtFnr = Fnr(person.fnr),
-        sykmeldtNavn = person.tilNavn(),
+        sykmeldtFnr = Fnr(kafkaMetadata.fnr),
+        sykmeldtNavn = sykmeldtNavn,
         perioder = sykmelding.sykmeldingsperioder.tilPerioderAG(),
         prognose = sykmelding.prognose?.getPrognose(),
         syketilfelleFom = sykmelding.syketilfelleStartDato,

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
@@ -91,7 +91,7 @@ class SykmeldingRoutingTest :
         }
     })
 
-fun SykmeldingDTO.toMockSykmeldingArbeidsgiver(): Sykmelding = tilSykmeldingArbeidsgiver(mockHentPersonFraPDL(fnr))
+fun SykmeldingDTO.toMockSykmeldingArbeidsgiver(): Sykmelding = tilSykmeldingArbeidsgiver()
 
 fun SendSykmeldingAivenKafkaMessage.toSykmeldingResponse(): SykmeldingDTO =
     SykmeldingDTO(
@@ -99,5 +99,5 @@ fun SendSykmeldingAivenKafkaMessage.toSykmeldingResponse(): SykmeldingDTO =
         kafkaMetadata.fnr,
         event.arbeidsgiver.orgnummer,
         this,
-        mockHentPersonFraPDL(kafkaMetadata.fnr).fornavn,
+        "Ola Nordmann",
     )

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
@@ -56,7 +56,7 @@ class SykmeldingRoutingTest :
         test("GET /v1/sykmelding/{id} skal returnere OK og sykmelding") {
 
             val sykmeldingDTO = sykmeldingMock().tilSykmeldingDTO()
-            val sykmelding = sykmeldingDTO.tilMockSykmeldingModel()
+            val sykmelding = sykmeldingDTO.tilSykmelding()
             val id = UUID.fromString(sykmeldingDTO.id)
 
             every { sykmeldingService.hentSykmelding(id, any()) } returns sykmelding
@@ -90,8 +90,6 @@ class SykmeldingRoutingTest :
             }
         }
     })
-
-fun SykmeldingDTO.tilMockSykmeldingModel(): Sykmelding = tilSykmelding()
 
 fun SendSykmeldingAivenKafkaMessage.tilSykmeldingDTO(): SykmeldingDTO =
     SykmeldingDTO(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.helsearbeidsgiver.sykmelding
 import io.kotest.matchers.shouldBe
 import no.nav.helsearbeidsgiver.config.DatabaseConfig
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingEntitet.sendSykmeldingAivenKafkaMessage
+import no.nav.helsearbeidsgiver.sykmelding.model.tilSykmelding
 import no.nav.helsearbeidsgiver.testcontainer.WithPostgresContainer
 import no.nav.helsearbeidsgiver.utils.TestData.sykmeldingMock
 import org.jetbrains.exposed.sql.Database
@@ -91,12 +92,12 @@ class SykmeldingServiceTest {
     @Test
     fun `hentSykmelding skal hente sykmelding`() {
         val sykmeldingKafkaMessage =
-            sykmeldingMock().also { sykmeldingService.lagreSykmelding(it, UUID.fromString(it.sykmelding.id), "") }
+            sykmeldingMock().also { sykmeldingService.lagreSykmelding(it, UUID.fromString(it.sykmelding.id), "Ola Nordmann") }
 
         val id = UUID.fromString(sykmeldingKafkaMessage.sykmelding.id)
         val orgnr = sykmeldingKafkaMessage.event.arbeidsgiver!!.orgnummer
 
-        sykmeldingService.hentSykmelding(id, orgnr) shouldBe sykmeldingKafkaMessage.tilSykmeldingDTO().tilMockSykmeldingModel()
+        sykmeldingService.hentSykmelding(id, orgnr) shouldBe sykmeldingKafkaMessage.tilSykmeldingDTO().tilSykmelding()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapperTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapperTest.kt
@@ -2,9 +2,7 @@ package no.nav.helsearbeidsgiver.sykmelding.model
 
 import io.kotest.matchers.shouldBe
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
-import no.nav.helsearbeidsgiver.sykmelding.SykmeldingDTO
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO
-import no.nav.helsearbeidsgiver.sykmelding.tilMockSykmeldingModel
 import no.nav.helsearbeidsgiver.sykmelding.tilSykmeldingDTO
 import no.nav.helsearbeidsgiver.utils.TestData.sykmeldingMock
 import no.nav.helsearbeidsgiver.utils.TestData.sykmeldingModelMock
@@ -33,18 +31,12 @@ class SykmeldingMapperTest {
                 svartype = SykmeldingStatusKafkaEventDTO.SvartypeDTO.DAGER,
                 svar = "[\"2025-03-27\",\"2025-03-29\",\"2025-03-26\"]",
             )
-
         val sykmelding =
-            SykmeldingDTO(
-                id = "",
-                fnr = "05117920005",
-                orgnr = "220460274",
-                sendSykmeldingAivenKafkaMessage =
-                    sykmeldingMock.copy(
-                        event = sykmeldingMock.event.copy(sporsmals = listOf(egenmeldingSvar)),
-                    ),
-                sykmeldtNavn = "",
-            ).tilMockSykmeldingModel()
+            sykmeldingMock
+                .copy(
+                    event = sykmeldingMock.event.copy(sporsmals = listOf(egenmeldingSvar)),
+                ).tilSykmeldingDTO()
+                .tilSykmelding()
 
         sykmelding.egenmeldingsdager shouldBe
             setOf(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapperTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapperTest.kt
@@ -4,7 +4,6 @@ import io.kotest.matchers.shouldBe
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingDTO
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO
-import no.nav.helsearbeidsgiver.sykmelding.mockHentPersonFraPDL
 import no.nav.helsearbeidsgiver.sykmelding.tilMockSykmeldingModel
 import no.nav.helsearbeidsgiver.sykmelding.tilSykmeldingDTO
 import no.nav.helsearbeidsgiver.utils.TestData.sykmeldingMock
@@ -17,11 +16,10 @@ class SykmeldingMapperTest {
     fun `tilSykmelding mapper fra sykmeldingDTO til Sykmelding model med riktig data`() {
         val sykmeldingKafkaMessage = sykmeldingMock()
         val sykmeldingDTO = sykmeldingKafkaMessage.tilSykmeldingDTO()
-        val person = mockHentPersonFraPDL(sykmeldingKafkaMessage.kafkaMetadata.fnr)
 
         val sykmeldingApiRespons = sykmeldingModelMock()
 
-        sykmeldingDTO.tilSykmelding(person) shouldBe sykmeldingApiRespons
+        sykmeldingDTO.tilSykmelding() shouldBe sykmeldingApiRespons
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
@@ -179,11 +179,7 @@ object TestData {
           ],
           "syketilfelleFom": "2020-03-15",
           "sykmeldtFnr": "01447842099",
-          "sykmeldtNavn": {
-            "etternavn": "Nordmann",
-            "mellomnavn": null,
-            "fornavn": "Ola"
-          },
+          "sykmeldtNavn": "Ola Nordmann",
           "arbeidsgiver": {
             "navn": "LOMMEN BARNEHAVE"
           },


### PR DESCRIPTION
Har vært en `TODO` kommentar i koden at vi må bruke navn hentet fra PDL.

Nylig har PDL navn blitt lagt til i DTO som sykmeldtNavn.

Denne PRen bruker vi den faktiske variabelen vi har lagret istedenfor en mock verdi i sykmeldingen

Demo i dev:
```bash
TOKEN=$(curl -s -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "orgnr=311567470" \
  https://hag-lps-api-client.ekstern.dev.nav.no/systembruker |  jq -r '.tokenResponse.access_token') && \
curl -s -H "Authorization: Bearer $TOKEN" \
  https://sykepenger-im-lps-api.ekstern.dev.nav.no/v1/sykmelding/0a380626-8856-4a8a-9960-97d00cb1041e | \
  jq -r '.sykmeldtNavn'
  
RAKRYGGET FABRIKK
```
