### PR TITLE
Samlet oppfølging til ett objekt

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -36,15 +36,19 @@ data class Sykmelding(
     val arbeidsgiver: Arbeidsgiver? = null,
     @field:Schema(description = "Sammenhengende, ikke overlappende perioder for denne sykmeldingen")
     val perioder: List<SykmeldingPeriode>? = null,
-    @field:Schema(description = "Prognose")
-    val prognose: Prognose? = null,
-    @field:Schema(description = "Innspill til tiltak som kan bedre arbeidsevnen")
-    val tiltak: Tiltak? = null,
     @field:Schema(description = "Øvrige kommentarer: kontakt mellom lege/arbeidsgiver - melding fra behandler")
-    val meldingTilArbeidsgiver: String? = null,
+    val oppfoelging: Oppfoelging,
     val kontaktMedPasient: KontaktMedPasient,
     val behandlerNavn: Navn,
     val behandlerTlf: String,
+)
+
+@Serializable
+data class Oppfoelging(
+    val prognose: Prognose? = null,
+    val meldingTilArbeidsgiver: String? = null,
+    @Schema(description = "Innspill til tiltak som kan bedre arbeidsevnen")
+    val tiltakArbeidsplassen: String? = null,
 )
 
 @Serializable
@@ -98,12 +102,6 @@ data class Prognose(
     val erArbeidsfoerEtterEndtPeriode: Boolean,
     @field:Schema(description = "Hvis arbeidsfør etter denne perioden: Beskriv eventuelle hensyn som må tas på arbeidsplassen.")
     val beskrivHensynArbeidsplassen: String? = null,
-)
-
-@Serializable
-@Schema(description = "Innspill til tiltak som kan bedre arbeidsevnen")
-data class Tiltak(
-    val tiltakArbeidsplassen: String? = null,
 )
 
 @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -36,7 +36,6 @@ data class Sykmelding(
     val arbeidsgiver: Arbeidsgiver? = null,
     @field:Schema(description = "Sammenhengende, ikke overlappende perioder for denne sykmeldingen")
     val perioder: List<SykmeldingPeriode>? = null,
-    @field:Schema(description = "Øvrige kommentarer: kontakt mellom lege/arbeidsgiver - melding fra behandler")
     val oppfoelging: Oppfoelging,
     @field:Schema(description = "Ved å oppgi informasjonen nedenfor bekreftes at personen er kjent eller har vist legitimasjon")
     val kontaktMedPasient: LocalDateTime,
@@ -47,6 +46,7 @@ data class Sykmelding(
 @Serializable
 data class Oppfoelging(
     val prognose: Prognose? = null,
+    @field:Schema(description = "Øvrige kommentarer: kontakt mellom lege/arbeidsgiver - melding fra behandler")
     val meldingTilArbeidsgiver: String? = null,
     @Schema(description = "Innspill til tiltak som kan bedre arbeidsevnen")
     val tiltakArbeidsplassen: String? = null,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapper.kt
@@ -4,6 +4,7 @@ package no.nav.helsearbeidsgiver.sykmelding.model
 
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
+import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.ArbeidsgiverAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.BehandlerAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.PrognoseAGDTO
@@ -35,15 +36,20 @@ fun SykmeldingDTO.tilSykmelding(person: Person): Sykmelding {
         behandlerNavn = sykmelding.behandler.tilNavn(),
         behandlerTlf = sykmelding.behandler?.tlf.tolkTelefonNr(),
         kontaktMedPasient = sykmelding.behandletTidspunkt.tilKontaktMedPasient(),
-        meldingTilArbeidsgiver = sykmelding.meldingTilArbeidsgiver,
         sykmeldtFnr = Fnr(person.fnr),
         sykmeldtNavn = person.tilNavn(),
         perioder = sykmelding.sykmeldingsperioder.tilPerioderAG(),
-        prognose = sykmelding.prognose?.getPrognose(),
         syketilfelleFom = sykmelding.syketilfelleStartDato,
-        tiltak = sykmelding.tiltakArbeidsplassen?.tilTiltak(),
+        oppfoelging = sykmelding.tilOppfoelging(),
     )
 }
+
+private fun ArbeidsgiverSykmeldingKafka.tilOppfoelging(): Oppfoelging =
+    Oppfoelging(
+        prognose = prognose?.getPrognose(),
+        meldingTilArbeidsgiver = meldingTilArbeidsgiver,
+        tiltakArbeidsplassen = tiltakArbeidsplassen,
+    )
 
 private fun List<SporsmalOgSvarDTO>?.tilEgenmeldingsdager(): Set<Periode> =
     this
@@ -53,12 +59,10 @@ private fun List<SporsmalOgSvarDTO>?.tilEgenmeldingsdager(): Set<Periode> =
         ?.tilPerioder()
         ?: emptySet()
 
-private fun String.tilTiltak(): Tiltak = Tiltak(tiltakArbeidsplassen = this)
-
 private fun PrognoseAGDTO.getPrognose(): Prognose =
     Prognose(
-        erArbeidsfoerEtterEndtPeriode = this.arbeidsforEtterPeriode,
-        beskrivHensynArbeidsplassen = this.hensynArbeidsplassen,
+        erArbeidsfoerEtterEndtPeriode = arbeidsforEtterPeriode,
+        beskrivHensynArbeidsplassen = hensynArbeidsplassen,
     )
 
 private fun List<SykmeldingsperiodeAGDTO>.tilPerioderAG(): List<SykmeldingPeriode> =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
@@ -203,9 +203,13 @@ object TestData {
               }
             }
           ],
-          "prognose": {
+          "oppfoelging" : {
+            "meldingTilArbeidsgiver": null,
+            "tiltakArbeidsplassen": "Fortsett som sist.",
+            "prognose": {
             "erArbeidsfoerEtterEndtPeriode": true,
             "beskrivHensynArbeidsplassen": "Må ta det pent"
+          }
           },
           "tiltak": {
             "tiltakArbeidsplassen": "Fortsett som sist."


### PR DESCRIPTION
Det er et mål at alle oppfølging relatert innhold i sykmelding skal være samlet i et objekt slik at det enklere kan ekskluderes i fremtiden.

Denne PRen samler de følgende feltene i sykmelding i `oppfoelging` variabelen:

- `meldingTilArbeidsgiver`
- `tiltakArbeidsplassen`
- `erArbeidsfoerEtterEndtPeriode`
- `beskrivHensynArbeidsplassen `