### PR TITLE
Flytt orgnr inn i arbeidsgiver for å samsvare med IM format

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -19,10 +19,6 @@ import java.time.LocalDateTime
 @Serializable
 @Schema(description = "SykmeldingArbeidsgiver")
 data class Sykmelding(
-    @field:Schema(description = "organisasjonsnummer for overenheten i bedriften den sykmeldte er knyttet til")
-    val orgnrHovedenhet: Orgnr?,
-    @field:Schema(description = "organisasjonsnummer for underenheten i bedriften den sykmeldte er knyttet til")
-    val orgnr: Orgnr,
     @field:Schema(description = "Sykmeldingens unike id")
     val sykmeldingId: String,
     @field:Schema(description = "Dato og tid for når sykmeldingen ble mottatt hos NAV")
@@ -33,7 +29,7 @@ data class Sykmelding(
     val sykmeldtFnr: Fnr,
     val sykmeldtNavn: Navn,
     @field:Schema(description = "Arbeidsgiver oppgitt av behandler")
-    val arbeidsgiver: Arbeidsgiver? = null,
+    val arbeidsgiver: Arbeidsgiver,
     @field:Schema(description = "Sammenhengende, ikke overlappende perioder for denne sykmeldingen")
     val perioder: List<SykmeldingPeriode>? = null,
     @field:Schema(description = "Prognose")
@@ -129,4 +125,8 @@ data class Navn(
 data class Arbeidsgiver(
     @field:Schema(description = "Navn på arbeidsgiver slik det fremkommer av sykmeldingen. Dette navnet fylles ut av lege.")
     val navn: String? = null,
+    @field:Schema(description = "organisasjonsnummer for overenheten i bedriften den sykmeldte er knyttet til")
+    val orgnrHovedenhet: Orgnr?,
+    @field:Schema(description = "organisasjonsnummer for underenheten i bedriften den sykmeldte er knyttet til")
+    val orgnr: Orgnr,
 )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -124,7 +124,7 @@ data class Navn(
 @Schema(description = "Arbeidsgiver")
 data class Arbeidsgiver(
     @field:Schema(description = "Navn på arbeidsgiver slik det fremkommer av sykmeldingen. Dette navnet fylles ut av lege.")
-    val navn: String? = null,
+    val navnFraBehandler: String? = null,
     @field:Schema(description = "organisasjonsnummer for overenheten i bedriften den sykmeldte er knyttet til")
     val orgnrHovedenhet: Orgnr?,
     @field:Schema(description = "organisasjonsnummer for underenheten i bedriften den sykmeldte er knyttet til")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapper.kt
@@ -111,7 +111,7 @@ private fun BehandlerAGDTO?.tilNavn(): Navn =
 
 private fun SendSykmeldingAivenKafkaMessage.tilArbeidsgiver(): Arbeidsgiver =
     Arbeidsgiver(
-        navn = sykmelding.arbeidsgiver.navn,
+        navnFraBehandler = sykmelding.arbeidsgiver.navn,
         orgnrHovedenhet = event.arbeidsgiver.juridiskOrgnummer?.let { Orgnr(it) },
         orgnr = event.arbeidsgiver.orgnummer.let { Orgnr(it) },
     )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapper.kt
@@ -112,6 +112,6 @@ private fun BehandlerAGDTO?.tilNavn(): Navn =
 private fun SendSykmeldingAivenKafkaMessage.tilArbeidsgiver(): Arbeidsgiver =
     Arbeidsgiver(
         navnFraBehandler = sykmelding.arbeidsgiver.navn,
-        orgnrHovedenhet = event.arbeidsgiver.juridiskOrgnummer?.let { Orgnr(it) },
-        orgnr = event.arbeidsgiver.orgnummer.let { Orgnr(it) },
+        orgnrHovedenhet = event.arbeidsgiver.juridiskOrgnummer?.let(::Orgnr),
+        orgnr = event.arbeidsgiver.orgnummer.let(::Orgnr),
     )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapper.kt
@@ -4,13 +4,13 @@ package no.nav.helsearbeidsgiver.sykmelding.model
 
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
-import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.ArbeidsgiverAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.BehandlerAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.PrognoseAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.SykmeldingsperiodeAGDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.SykmeldingsperiodeAGDTO.AktivitetIkkeMuligAGDTO.ArbeidsrelatertArsakDTO
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.SykmeldingsperiodeAGDTO.AktivitetIkkeMuligAGDTO.ArbeidsrelatertArsakDTO.ArbeidsrelatertArsakTypeDTO.MANGLENDE_TILRETTELEGGING
 import no.nav.helsearbeidsgiver.sykmelding.ArbeidsgiverSykmeldingKafka.SykmeldingsperiodeAGDTO.GradertDTO
+import no.nav.helsearbeidsgiver.sykmelding.SendSykmeldingAivenKafkaMessage
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingDTO
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO.ShortNameDTO
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO.SporsmalOgSvarDTO
@@ -26,12 +26,10 @@ fun SykmeldingDTO.tilSykmelding(person: Person): Sykmelding {
     val sykmelding = sendSykmeldingAivenKafkaMessage.sykmelding
     val event = sendSykmeldingAivenKafkaMessage.event
     return Sykmelding(
-        orgnrHovedenhet = event.arbeidsgiver.juridiskOrgnummer?.let { Orgnr(it) },
-        mottattidspunkt = sykmelding.mottattTidspunkt.toLocalDateTime(),
         sykmeldingId = sykmelding.id,
-        orgnr = event.arbeidsgiver.orgnummer.let { Orgnr(it) },
+        mottattidspunkt = sykmelding.mottattTidspunkt.toLocalDateTime(),
+        arbeidsgiver = sendSykmeldingAivenKafkaMessage.tilArbeidsgiver(),
         egenmeldingsdager = event.sporsmals.tilEgenmeldingsdager(),
-        arbeidsgiver = sykmelding.arbeidsgiver.tilArbeidsgiver(),
         behandlerNavn = sykmelding.behandler.tilNavn(),
         behandlerTlf = sykmelding.behandler?.tlf.tolkTelefonNr(),
         kontaktMedPasient = sykmelding.behandletTidspunkt.tilKontaktMedPasient(),
@@ -111,7 +109,9 @@ private fun BehandlerAGDTO?.tilNavn(): Navn =
         mellomnavn = this?.mellomnavn ?: "",
     )
 
-private fun ArbeidsgiverAGDTO.tilArbeidsgiver(): Arbeidsgiver =
+private fun SendSykmeldingAivenKafkaMessage.tilArbeidsgiver(): Arbeidsgiver =
     Arbeidsgiver(
-        navn = this.navn,
+        navn = sykmelding.arbeidsgiver.navn,
+        orgnrHovedenhet = event.arbeidsgiver.juridiskOrgnummer?.let { Orgnr(it) },
+        orgnr = event.arbeidsgiver.orgnummer.let { Orgnr(it) },
     )

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
@@ -167,8 +167,6 @@ object TestData {
     const val SYKMELDING_API_RESPONSE =
         """
         {
-          "orgnrHovedenhet": "744372453",
-          "orgnr": "315587336",
           "sykmeldingId": "b5f66f7a-d1a9-483c-a9d1-e4d45a7bba4d",
           "mottattidspunkt": "2020-03-14T23:00",
           "egenmeldingsdager": [
@@ -185,7 +183,9 @@ object TestData {
             "fornavn": "Ola"
           },
           "arbeidsgiver": {
-            "navn": "LOMMEN BARNEHAVE"
+            "navn": "LOMMEN BARNEHAVE",
+            "orgnrHovedenhet": "744372453",
+            "orgnr": "315587336"
           },
           "perioder": [
             {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
@@ -183,7 +183,7 @@ object TestData {
             "fornavn": "Ola"
           },
           "arbeidsgiver": {
-            "navn": "LOMMEN BARNEHAVE",
+            "navnFraBehandler": "LOMMEN BARNEHAVE",
             "orgnrHovedenhet": "744372453",
             "orgnr": "315587336"
           },


### PR DESCRIPTION
Fra møte om sykmelding format ble vi enig om å endre formatet for å samsvare med inntektsmeldingen der mulig.

for inntektsmelding ser `arbeidsgiver` slik:
```json
"arbeidsgiver": {
  "orgnr": "315587336",
  "tlf": "12345678"
},
```

Denne PRen flytter orgnr inn i arbeidsgiver for å samsvare mer med dette inntektsmelding formatet:

```kotlin
data class Arbeidsgiver(
    val orgnr: Orgnr,
    val orgnrHovedenhet: Orgnr?,
    // Navn på arbeidsgiver slik det fremkommer av sykmeldingen. Dette navnet fylles ut av lege
    val navnFraBehandler: String? = null,
)
```