### PR TITLE
forenkle kontaktMedPasient

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -42,6 +42,7 @@ data class Sykmelding(
     val tiltak: Tiltak? = null,
     @field:Schema(description = "Øvrige kommentarer: kontakt mellom lege/arbeidsgiver - melding fra behandler")
     val meldingTilArbeidsgiver: String? = null,
+    @field:Schema(description = "Ved å oppgi informasjonen nedenfor bekreftes at personen er kjent eller har vist legitimasjon")
     val kontaktMedPasient: LocalDateTime,
     val behandlerNavn: Navn,
     val behandlerTlf: String,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/Sykmelding.kt
@@ -42,7 +42,7 @@ data class Sykmelding(
     val tiltak: Tiltak? = null,
     @field:Schema(description = "Øvrige kommentarer: kontakt mellom lege/arbeidsgiver - melding fra behandler")
     val meldingTilArbeidsgiver: String? = null,
-    val kontaktMedPasient: KontaktMedPasient,
+    val kontaktMedPasient: LocalDateTime,
     val behandlerNavn: Navn,
     val behandlerTlf: String,
 )
@@ -104,13 +104,6 @@ data class Prognose(
 @Schema(description = "Innspill til tiltak som kan bedre arbeidsevnen")
 data class Tiltak(
     val tiltakArbeidsplassen: String? = null,
-)
-
-@Serializable
-@Schema(description = "Kontakt med pasient")
-data class KontaktMedPasient(
-    @field:Schema(description = "Ved å oppgi informasjonen nedenfor bekreftes at personen er kjent eller har vist legitimasjon")
-    val behandlet: LocalDateTime,
 )
 
 @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapper.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/model/SykmeldingMapper.kt
@@ -20,7 +20,6 @@ import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import no.nav.helsearbeidsgiver.utils.tilPerioder
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
-import java.time.OffsetDateTime
 
 fun SykmeldingDTO.tilSykmelding(person: Person): Sykmelding {
     val sykmelding = sendSykmeldingAivenKafkaMessage.sykmelding
@@ -34,7 +33,7 @@ fun SykmeldingDTO.tilSykmelding(person: Person): Sykmelding {
         arbeidsgiver = sykmelding.arbeidsgiver.tilArbeidsgiver(),
         behandlerNavn = sykmelding.behandler.tilNavn(),
         behandlerTlf = sykmelding.behandler?.tlf.tolkTelefonNr(),
-        kontaktMedPasient = sykmelding.behandletTidspunkt.tilKontaktMedPasient(),
+        kontaktMedPasient = sykmelding.behandletTidspunkt.toLocalDateTime(),
         meldingTilArbeidsgiver = sykmelding.meldingTilArbeidsgiver,
         sykmeldtFnr = Fnr(person.fnr),
         sykmeldtNavn = person.tilNavn(),
@@ -93,8 +92,6 @@ private fun Person.tilNavn(): Navn =
         mellomnavn = mellomnavn,
         etternavn = etternavn,
     )
-
-private fun OffsetDateTime.tilKontaktMedPasient(): KontaktMedPasient = KontaktMedPasient(behandlet = this.toLocalDateTime())
 
 fun String?.tolkTelefonNr(): String =
     this

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
@@ -211,9 +211,7 @@ object TestData {
             "tiltakArbeidsplassen": "Fortsett som sist."
           },
           "meldingTilArbeidsgiver": null,
-          "kontaktMedPasient": {
-            "behandlet": "2020-03-14T23:00"
-          },
+          "kontaktMedPasient": "2020-03-14T23:00",
           "behandlerNavn": {
             "etternavn": "Frost",
             "mellomnavn": "Perma",


### PR DESCRIPTION
Det er et mål at sykmelding formatet burde forenkles der mulig.

I denne PRen blir feltet `kontaktMedPasient.behandlet` forenklet til bare `kontaktMedPasient`