### PR TITLE
Opprett dialoger med kafka

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -52,7 +52,6 @@ spec:
           name: im.read
       consumes:
         - name: "altinn:authorization/authorize"
-        - name: "digdir:dialogporten.serviceprovider"
   azure:
     application:
       enabled: true
@@ -74,8 +73,6 @@ spec:
       value: "nav_sykepenger_inntektsmelding-nedlasting"
     - name: ALTINN_PDP_SCOPE
       value: "altinn:authorization/authorize"
-    - name: DIALOGPORTEN_SCOPE
-      value: "digdir:dialogporten.serviceprovider"
     - name: NAV_ARBEIDSGIVER_PORTAL_BASEURL
       value: "https://arbeidsgiver.intern.dev.nav.no"
     - name: NAV_ARBEIDSGIVER_API_BASEURL

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 val bakgrunnsjobbVersion: String by project
 val coroutineVersion: String by project
-val dialogportenClientVersion: String by project
 val exposedVersion: String by project
 val flywayCoreVersion: String by project
 val hagDomeneInntektsmeldingVersion: String by project
@@ -69,7 +68,6 @@ dependencies {
     implementation("io.swagger.core.v3:swagger-annotations:$swaggerVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:$logbackEncoderVersion")
     implementation("no.nav.helsearbeidsgiver:altinn-pdp-client:$pdpClientVersion")
-    implementation("no.nav.helsearbeidsgiver:dialogporten-client:$dialogportenClientVersion")
     implementation("no.nav.helsearbeidsgiver:domene-inntektsmelding:$hagDomeneInntektsmeldingVersion")
     implementation("no.nav.helsearbeidsgiver:hag-bakgrunnsjobb:$bakgrunnsjobbVersion")
     implementation("no.nav.helsearbeidsgiver:pdl-client:$pdlKlientVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@ kotlin.code.style=official
 
 bakgrunnsjobbVersion=1.0.7
 coroutineVersion=1.6.4
-dialogportenClientVersion=1.0.0
 exposedVersion=0.60.0
 flywayCoreVersion=10.20.0
 hagDomeneInntektsmeldingVersion=0.3.1

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/Application.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/Application.kt
@@ -14,7 +14,6 @@ import no.nav.helsearbeidsgiver.config.configureKafkaConsumers
 import no.nav.helsearbeidsgiver.config.configureRepositories
 import no.nav.helsearbeidsgiver.config.configureServices
 import no.nav.helsearbeidsgiver.config.configureTolkere
-import no.nav.helsearbeidsgiver.config.configureUnleashFeatureToggles
 import no.nav.helsearbeidsgiver.felles.auth.AuthClient
 import no.nav.helsearbeidsgiver.plugins.configureRouting
 import no.nav.helsearbeidsgiver.utils.log.logger
@@ -28,8 +27,6 @@ fun startServer() {
     val sikkerLogger = sikkerLogger()
     sikkerLogger.info("Setter opp database...")
     val db = DatabaseConfig().init()
-    sikkerLogger.info("Setter opp Unleash...")
-    val unleashFeatureToggles = configureUnleashFeatureToggles()
     sikkerLogger.info("Setter opp repositories og services...")
     val repositories = configureRepositories(db)
 
@@ -40,7 +37,6 @@ fun startServer() {
         configureTolkere(
             services = services,
             repositories = repositories,
-            unleashFeatureToggles = unleashFeatureToggles,
         )
 
     embeddedServer(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/auth/AuthClientAltinnUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/auth/AuthClientAltinnUtils.kt
@@ -16,5 +16,3 @@ private fun AuthClient.hentAltinnToken(target: String): () -> String {
 }
 
 fun AuthClient.pdpTokenGetter() = hentAltinnToken(Env.getProperty("ALTINN_PDP_SCOPE"))
-
-fun AuthClient.dialogportenTokenGetter() = hentAltinnToken(Env.getProperty("DIALOGPORTEN_SCOPE"))

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
@@ -18,7 +18,6 @@ import no.nav.helsearbeidsgiver.dialogporten.DialogProducer
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
 import no.nav.helsearbeidsgiver.dialogporten.IDialogportenService
 import no.nav.helsearbeidsgiver.dialogporten.IngenDialogportenService
-import no.nav.helsearbeidsgiver.dialogporten.lagDialogportenClient
 import no.nav.helsearbeidsgiver.felles.auth.AuthClient
 import no.nav.helsearbeidsgiver.felles.auth.DefaultAuthClient
 import no.nav.helsearbeidsgiver.felles.auth.NoOpAuthClient
@@ -87,7 +86,6 @@ data class Tolkere(
 fun configureTolkere(
     services: Services,
     repositories: Repositories,
-    unleashFeatureToggles: UnleashFeatureToggles,
 ): Tolkere {
     val inntektsmeldingTolker =
         InntektsmeldingTolker(
@@ -170,7 +168,6 @@ fun configureServices(
                     ),
                 )
             DialogportenService(
-                lagDialogportenClient(authClient = authClient),
                 dialogProducer = dialogProducer,
             )
         } else {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
@@ -96,7 +96,6 @@ fun configureTolkere(
         ForespoerselTolker(
             forespoerselRepository = repositories.forespoerselRepository,
             mottakRepository = repositories.mottakRepository,
-            dialogportenService = services.dialogportenService,
         )
     val sykmeldingTolker =
         SykmeldingTolker(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
@@ -105,7 +105,6 @@ fun configureTolkere(
             sykmeldingService = services.sykmeldingService,
             dialogportenService = services.dialogportenService,
             pdlService = services.pdlService,
-            unleashFeatureToggles = unleashFeatureToggles,
         )
 
     return Tolkere(inntektsmeldingTolker, forespoerselTolker, sykmeldingTolker)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogMelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogMelding.kt
@@ -1,0 +1,26 @@
+@file:UseSerializers(LocalDateSerializer::class, UuidSerializer::class)
+
+package no.nav.helsearbeidsgiver.dialogporten
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
+import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
+import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
+import java.time.LocalDate
+import java.util.UUID
+
+@Serializable
+sealed class DialogMelding
+
+@Serializable
+@SerialName("Sykmelding")
+data class DialogSykmelding(
+    val sykmeldingId: UUID,
+    val orgnr: Orgnr,
+    val foedselsdato: LocalDate,
+    val fulltNavn: String,
+    val sykmeldingsperioder: List<Periode>,
+) : DialogMelding()

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogProducer.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogProducer.kt
@@ -19,9 +19,9 @@ class DialogProducer(
             kafkaProducer.send(message.toRecord()).get()
         }.map { message }
             .onSuccess {
-                sikkerLogger().info("Publiserte melding om dialog skjema på topic $topic:\n${it.toPretty()}")
+                sikkerLogger().info("Publiserte melding om dialog på topic $topic:\n${it.toPretty()}")
             }.getOrElse {
-                sikkerLogger().error("Klarte ikke publisere melding om innsendt skjema på topic $topic:\n${message.toPretty()}")
+                sikkerLogger().error("Klarte ikke publisere melding om dialog på topic $topic:\n${message.toPretty()}")
                 throw it
             }
     }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogProducer.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogProducer.kt
@@ -1,0 +1,30 @@
+package no.nav.helsearbeidsgiver.dialogporten
+
+import kotlinx.serialization.json.JsonElement
+import no.nav.helsearbeidsgiver.Env.getProperty
+import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.json.toPretty
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+
+class DialogProducer(
+    private val kafkaProducer: KafkaProducer<String, JsonElement>,
+) {
+    private val topic = getProperty("kafkaProducer.dialog.topic")
+
+    fun send(dialogMelding: DialogMelding) {
+        val message = dialogMelding.toJson(DialogMelding.serializer())
+        runCatching {
+            kafkaProducer.send(message.toRecord()).get()
+        }.map { message }
+            .onSuccess {
+                sikkerLogger().info("Publiserte melding om dialog skjema på topic $topic:\n${it.toPretty()}")
+            }.getOrElse {
+                sikkerLogger().error("Klarte ikke publisere melding om innsendt skjema på topic $topic:\n${message.toPretty()}")
+                throw it
+            }
+    }
+
+    private fun JsonElement.toRecord(): ProducerRecord<String, JsonElement> = ProducerRecord(topic, this)
+}

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/Dialogporten.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/Dialogporten.kt
@@ -10,7 +10,7 @@ import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import java.util.UUID
 
 interface IDialogportenService {
-    fun sendDialogPåKafka(dialog: DialogSykmelding)
+    fun opprettNyDialogMedSykmelding(dialog: DialogSykmelding)
 
     fun opprettNyDialogMedSykmelding(
         orgnr: String,
@@ -20,7 +20,7 @@ interface IDialogportenService {
 }
 
 class IngenDialogportenService : IDialogportenService {
-    override fun sendDialogPåKafka(dialog: DialogSykmelding) {
+    override fun opprettNyDialogMedSykmelding(dialog: DialogSykmelding) {
         val generertId = UUID.randomUUID()
         sikkerLogger().info("Oppretter ikke dialog for sykmelding generertId: $generertId")
     }
@@ -40,10 +40,9 @@ class DialogportenService(
     val dialogportenClient: DialogportenClient,
     val dialogProducer: DialogProducer,
 ) : IDialogportenService {
-    private val navPortalBaseUrl = Env.getProperty("NAV_ARBEIDSGIVER_PORTAL_BASEURL")
     private val navApiBaseUrl = Env.getProperty("NAV_ARBEIDSGIVER_API_BASEURL")
 
-    override fun sendDialogPåKafka(dialog: DialogSykmelding) {
+    override fun opprettNyDialogMedSykmelding(dialog: DialogSykmelding) {
         dialogProducer.send(dialog)
         sikkerLogger().info("Sender dialog for sykmelding med sykmeldingId: ${dialog.sykmeldingId}, på orgnr: ${dialog.orgnr}")
     }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/Dialogporten.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/Dialogporten.kt
@@ -10,6 +10,8 @@ import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import java.util.UUID
 
 interface IDialogportenService {
+    fun sendDialogPåKafka(dialog: DialogSykmelding)
+
     fun opprettNyDialogMedSykmelding(
         orgnr: String,
         sykmeldingId: UUID,
@@ -18,6 +20,11 @@ interface IDialogportenService {
 }
 
 class IngenDialogportenService : IDialogportenService {
+    override fun sendDialogPåKafka(dialog: DialogSykmelding) {
+        val generertId = UUID.randomUUID()
+        sikkerLogger().info("Oppretter ikke dialog for sykmelding generertId: $generertId")
+    }
+
     override fun opprettNyDialogMedSykmelding(
         orgnr: String,
         forespoerselId: UUID,
@@ -31,9 +38,15 @@ class IngenDialogportenService : IDialogportenService {
 
 class DialogportenService(
     val dialogportenClient: DialogportenClient,
+    val dialogProducer: DialogProducer,
 ) : IDialogportenService {
     private val navPortalBaseUrl = Env.getProperty("NAV_ARBEIDSGIVER_PORTAL_BASEURL")
     private val navApiBaseUrl = Env.getProperty("NAV_ARBEIDSGIVER_API_BASEURL")
+
+    override fun sendDialogPåKafka(dialog: DialogSykmelding) {
+        dialogProducer.send(dialog)
+        sikkerLogger().info("Sender dialog for sykmelding med sykmeldingId: ${dialog.sykmeldingId}, på orgnr: ${dialog.orgnr}")
+    }
 
     override fun opprettNyDialogMedSykmelding(
         orgnr: String,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/Dialogporten.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/Dialogporten.kt
@@ -1,22 +1,10 @@
 package no.nav.helsearbeidsgiver.dialogporten
 
-import kotlinx.coroutines.runBlocking
-import no.nav.helsearbeidsgiver.Env
-import no.nav.helsearbeidsgiver.auth.dialogportenTokenGetter
-import no.nav.helsearbeidsgiver.felles.auth.AuthClient
-import no.nav.helsearbeidsgiver.sykmelding.SendSykmeldingAivenKafkaMessage
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
-import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import java.util.UUID
 
 interface IDialogportenService {
     fun opprettNyDialogMedSykmelding(dialog: DialogSykmelding)
-
-    fun opprettNyDialogMedSykmelding(
-        orgnr: String,
-        sykmeldingId: UUID,
-        sykmeldingMessage: SendSykmeldingAivenKafkaMessage,
-    ): String
 }
 
 class IngenDialogportenService : IDialogportenService {
@@ -24,68 +12,13 @@ class IngenDialogportenService : IDialogportenService {
         val generertId = UUID.randomUUID()
         sikkerLogger().info("Oppretter ikke dialog for sykmelding generertId: $generertId")
     }
-
-    override fun opprettNyDialogMedSykmelding(
-        orgnr: String,
-        forespoerselId: UUID,
-        sykmeldingMessage: SendSykmeldingAivenKafkaMessage,
-    ): String {
-        val generertId = UUID.randomUUID()
-        sikkerLogger().info("Oppretter ikke dialog med sykmelding for : $forespoerselId, på orgnr: $orgnr, generertId: $generertId")
-        return generertId.toString()
-    }
 }
 
 class DialogportenService(
-    val dialogportenClient: DialogportenClient,
     val dialogProducer: DialogProducer,
 ) : IDialogportenService {
-    private val navApiBaseUrl = Env.getProperty("NAV_ARBEIDSGIVER_API_BASEURL")
-
     override fun opprettNyDialogMedSykmelding(dialog: DialogSykmelding) {
         dialogProducer.send(dialog)
         sikkerLogger().info("Sender dialog for sykmelding med sykmeldingId: ${dialog.sykmeldingId}, på orgnr: ${dialog.orgnr}")
     }
-
-    override fun opprettNyDialogMedSykmelding(
-        orgnr: String,
-        sykmeldingId: UUID,
-        sykmeldingMessage: SendSykmeldingAivenKafkaMessage,
-    ): String =
-        runBlocking {
-            dialogportenClient
-                .opprettNyDialogMedSykmelding(
-                    orgnr = orgnr,
-                    dialogTittel = "Sykepenger for Fornavn Etternavnsen (f. ${sykmeldingMessage.getFoedselsdatoString()})",
-                    dialogSammendrag = sykmeldingMessage.getSykmeldingsPerioderString(),
-                    sykmeldingId = sykmeldingId,
-                    sykmeldingJsonUrl = "$navApiBaseUrl/sykmelding/$sykmeldingId",
-                )
-        }
 }
-
-private fun SendSykmeldingAivenKafkaMessage.getSykmeldingsPerioderString(): String =
-    when (this.sykmelding.sykmeldingsperioder.size) {
-        1 -> "Sykmeldingsperiode ${this.sykmelding.sykmeldingsperioder[0].fom} - ${this.sykmelding.sykmeldingsperioder[0].tom}"
-        else ->
-            "Sykmeldingsperioder ${this.sykmelding.sykmeldingsperioder.first().fom} - (...) - " +
-                "${this.sykmelding.sykmeldingsperioder.last().tom}"
-    }
-
-// Støtter d-nummer
-private fun SendSykmeldingAivenKafkaMessage.getFoedselsdatoString(): String {
-    val fnr = Fnr(this.kafkaMetadata.fnr)
-    val foersteSiffer = fnr.verdi.first().digitToInt()
-    return if (foersteSiffer < 4) {
-        fnr.verdi.take(6)
-    } else {
-        (foersteSiffer - 4).toString() + fnr.verdi.substring(1, 6)
-    }
-}
-
-fun lagDialogportenClient(authClient: AuthClient) =
-    DialogportenClient(
-        baseUrl = Env.getProperty("ALTINN_3_BASE_URL"),
-        ressurs = Env.getProperty("ALTINN_IM_RESSURS"),
-        getToken = authClient.dialogportenTokenGetter(),
-    )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/ForespoerselTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/ForespoerselTolker.kt
@@ -1,6 +1,5 @@
 package no.nav.helsearbeidsgiver.kafka.forespoersel
 
-import no.nav.helsearbeidsgiver.dialogporten.IDialogportenService
 import no.nav.helsearbeidsgiver.forespoersel.ForespoerselRepository
 import no.nav.helsearbeidsgiver.kafka.MeldingTolker
 import no.nav.helsearbeidsgiver.kafka.forespoersel.pri.BehovMessage
@@ -17,7 +16,6 @@ import java.util.UUID
 class ForespoerselTolker(
     private val forespoerselRepository: ForespoerselRepository,
     private val mottakRepository: MottakRepository,
-    private val dialogportenService: IDialogportenService,
 ) : MeldingTolker {
     private val sikkerLogger = LoggerFactory.getLogger("tjenestekall")
     private val logger = logger()

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/innsending/InnsendingProducer.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/innsending/InnsendingProducer.kt
@@ -60,5 +60,6 @@ class InnsendingProducer(
                 kafkaProducer.send(this).get()
             }.map { message }
 
+    // TODO publiser på key forespoerselid for å partisjonere riktig
     private fun JsonElement.toRecord(): ProducerRecord<String, JsonElement> = ProducerRecord(topic, this)
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/sykmelding/SykmeldingTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/sykmelding/SykmeldingTolker.kt
@@ -1,6 +1,5 @@
 package no.nav.helsearbeidsgiver.kafka.sykmelding
 
-import no.nav.helsearbeidsgiver.dialogporten.DialogProducer
 import no.nav.helsearbeidsgiver.dialogporten.DialogSykmelding
 import no.nav.helsearbeidsgiver.dialogporten.IDialogportenService
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
@@ -21,7 +20,6 @@ class SykmeldingTolker(
     private val sykmeldingService: SykmeldingService,
     private val dialogportenService: IDialogportenService,
     private val pdlService: IPdlService,
-    private val dialogProducer: DialogProducer,
     private val unleashFeatureToggles: UnleashFeatureToggles,
 ) : MeldingTolker {
     private val sikkerLogger = sikkerLogger()
@@ -48,7 +46,6 @@ class SykmeldingTolker(
                         fulltNavn = fullPerson.navn.fulltNavn(),
                         sykmeldingsperioder = sykmeldingMessage.sykmelding.sykmeldingsperioder.map { Periode(it.fom, it.tom) },
                     )
-                dialogProducer.send(dialogSykmelding)
                 dialogportenService.opprettNyDialogMedSykmelding(
                     orgnr = sykmeldingMessage.event.arbeidsgiver.orgnummer,
                     sykmeldingId = sykmeldingId,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/pdl/PdlService.kt
@@ -32,6 +32,6 @@ class PdlService(
         runBlocking {
             sykmeldingPdlClient
                 .personBolk(listOf(fnr))
-                ?.firstOrNull() ?: throw RuntimeException("Fant ikke person")
+                ?.firstOrNull() ?: throw RuntimeException("Fant ikke person i pdl")
         }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/pdl/PdlService.kt
@@ -7,14 +7,10 @@ import no.nav.helsearbeidsgiver.felles.auth.AuthClientIdentityProvider.AZURE_AD
 import no.nav.helsearbeidsgiver.pdl.domene.FullPerson
 
 interface IPdlService {
-    fun hentPersonFulltNavnForSykmelding(fnr: String): String?
-
     fun hentFullPerson(fnr: String): FullPerson
 }
 
 class IngenPdlService : IPdlService {
-    override fun hentPersonFulltNavnForSykmelding(fnr: String): String? = "PDL skrudd av i prod"
-
     override fun hentFullPerson(fnr: String): FullPerson {
         TODO("Not yet implemented")
     }
@@ -37,14 +33,5 @@ class PdlService(
             sykmeldingPdlClient
                 .personBolk(listOf(fnr))
                 ?.firstOrNull() ?: throw RuntimeException("Fant ikke person")
-        }
-
-    override fun hentPersonFulltNavnForSykmelding(fnr: String): String? =
-        runBlocking {
-            sykmeldingPdlClient
-                .personBolk(listOf(fnr))
-                ?.firstOrNull()
-                ?.navn
-                ?.fulltNavn()
         }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/pdl/PdlService.kt
@@ -4,13 +4,20 @@ import kotlinx.coroutines.runBlocking
 import no.nav.helsearbeidsgiver.Env
 import no.nav.helsearbeidsgiver.felles.auth.AuthClient
 import no.nav.helsearbeidsgiver.felles.auth.AuthClientIdentityProvider.AZURE_AD
+import no.nav.helsearbeidsgiver.pdl.domene.FullPerson
 
 interface IPdlService {
     fun hentPersonFulltNavnForSykmelding(fnr: String): String?
+
+    fun hentFullPerson(fnr: String): FullPerson
 }
 
 class IngenPdlService : IPdlService {
     override fun hentPersonFulltNavnForSykmelding(fnr: String): String? = "PDL skrudd av i prod"
+
+    override fun hentFullPerson(fnr: String): FullPerson {
+        TODO("Not yet implemented")
+    }
 }
 
 class PdlService(
@@ -24,6 +31,13 @@ class PdlService(
             getAccessToken = tokenGetter,
             behandlingsgrunnlag = Behandlingsgrunnlag.SYKMELDING,
         )
+
+    override fun hentFullPerson(fnr: String): FullPerson =
+        runBlocking {
+            sykmeldingPdlClient
+                .personBolk(listOf(fnr))
+                ?.firstOrNull() ?: throw RuntimeException("Fant ikke person")
+        }
 
     override fun hentPersonFulltNavnForSykmelding(fnr: String): String? =
         runBlocking {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -13,6 +13,9 @@ kafkaProducer {
   innsending {
     topic = helsearbeidsgiver.api-innsending
   }
+  dialog {
+    topic = helsearbeidsgiver.dialog
+  }
 }
 database {
   username = "lpsapi"

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
@@ -16,9 +16,8 @@ import java.time.LocalDate
 import java.util.UUID
 
 class DialogportenServiceTest {
-    val mockDialogportenClient = mockk<DialogportenClient>()
     val mockDialogProducer = mockk<DialogProducer>()
-    val dialogportenService = DialogportenService(mockDialogportenClient, mockDialogProducer)
+    val dialogportenService = DialogportenService(mockDialogProducer)
 
     @Test
     fun `dialogporten service kaller dialogProducer`() {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
@@ -1,11 +1,18 @@
 package no.nav.helsearbeidsgiver.dialogporten
 
 import io.kotest.assertions.throwables.shouldThrowExactly
-import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.just
 import io.mockk.mockk
-import no.nav.helsearbeidsgiver.utils.TestData.sykmeldingMock
+import io.mockk.verify
+import kotlinx.serialization.SerializationException
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
+import no.nav.helsearbeidsgiver.utils.test.date.januar
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import java.util.UUID
 
 class DialogportenServiceTest {
@@ -14,46 +21,45 @@ class DialogportenServiceTest {
     val dialogportenService = DialogportenService(mockDialogportenClient, mockDialogProducer)
 
     @Test
-    fun `dialogporten klient videresender resultatet`() {
-        val orgnr = "1234"
-        val forespoereslId = UUID.randomUUID()
-        val forventetDialogId = UUID.randomUUID()
-        coEvery {
-            mockDialogportenClient.opprettNyDialogMedSykmelding(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
+    fun `dialogporten service kaller dialogProducer`() {
+        val dialogMelding =
+            DialogSykmelding(
+                sykmeldingId = UUID.randomUUID(),
+                orgnr = Orgnr.genererGyldig(),
+                foedselsdato = LocalDate.now(),
+                fulltNavn = "John Smith",
+                sykmeldingsperioder = listOf(Periode(fom = 1.januar, tom = 12.januar)),
             )
-        } returns forventetDialogId.toString()
 
-        dialogportenService.opprettNyDialogMedSykmelding(
-            orgnr,
-            forespoereslId,
-            sykmeldingMessage = sykmeldingMock(),
-        ) shouldBe forventetDialogId.toString()
+        coEvery { mockDialogProducer.send(any()) } just Runs
+
+        dialogportenService.opprettNyDialogMedSykmelding(dialogMelding)
+
+        verify(exactly = 1) {
+            mockDialogProducer.send(dialogMelding)
+        }
     }
 
     @Test
     fun `dialogporten service kaster feil dersom opprettelse av dialog går galt`() {
-        val orgnr = "1234"
-        val forespoereslId = UUID.randomUUID()
+        val dialogMelding =
+            DialogSykmelding(
+                sykmeldingId = UUID.randomUUID(),
+                orgnr = Orgnr.genererGyldig(),
+                foedselsdato = LocalDate.now(),
+                fulltNavn = "John Smith",
+                sykmeldingsperioder = listOf(Periode(fom = 1.januar, tom = 12.januar)),
+            )
+
         coEvery {
-            mockDialogportenClient.opprettNyDialogMedSykmelding(
-                any(),
-                any(),
-                any(),
-                any(),
+            mockDialogProducer.send(
                 any(),
             )
-        } throws DialogportenClientException("Noe gikk galt")
+        } throws SerializationException("Noe gikk galt")
 
-        shouldThrowExactly<DialogportenClientException> {
+        shouldThrowExactly<SerializationException> {
             dialogportenService.opprettNyDialogMedSykmelding(
-                orgnr,
-                forespoereslId,
-                sykmeldingMessage = sykmeldingMock(),
+                dialogMelding,
             )
         }
     }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
@@ -10,7 +10,8 @@ import java.util.UUID
 
 class DialogportenServiceTest {
     val mockDialogportenClient = mockk<DialogportenClient>()
-    val dialogportenService = DialogportenService(mockDialogportenClient)
+    val mockDialogProducer = mockk<DialogProducer>()
+    val dialogportenService = DialogportenService(mockDialogportenClient, mockDialogProducer)
 
     @Test
     fun `dialogporten klient videresender resultatet`() {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ForespoerselIT.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ForespoerselIT.kt
@@ -70,7 +70,6 @@ class ForespoerselIT {
             ForespoerselTolker(
                 forespoerselRepository = repositories.forespoerselRepository,
                 mottakRepository = repositories.mottakRepository,
-                dialogportenService = dialogportenService,
             )
     }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/KafkaCommitOffsetTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/KafkaCommitOffsetTest.kt
@@ -50,7 +50,6 @@ class KafkaCommitOffsetTest {
                 ForespoerselTolker(
                     mockk(),
                     mockk(),
-                    mockk(),
                 ),
             )
         val topicPartition = TopicPartition("test", 0)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/KafkaErrorHandlingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/KafkaErrorHandlingTest.kt
@@ -39,7 +39,7 @@ class KafkaErrorHandlingTest {
                 System.getProperty("database.password"),
             ).init()
         forespoerselRepository = ForespoerselRepository(db)
-        forespoerselTolker = ForespoerselTolker(forespoerselRepository, mockMottakRepository, mockDialogportenService)
+        forespoerselTolker = ForespoerselTolker(forespoerselRepository, mockMottakRepository)
     }
 
     @BeforeEach
@@ -60,7 +60,7 @@ class KafkaErrorHandlingTest {
     fun `ugyldig forespørsel i forespørselMottatt-melding skal bare lagre til mottak og gå videre`() {
         every { mockMottakRepository.opprett(any()) } returns 100
         val mockForespoerselRepository = mockk<ForespoerselRepository>()
-        val mockConsumer = ForespoerselTolker(mockForespoerselRepository, mockMottakRepository, mockDialogportenService)
+        val mockConsumer = ForespoerselTolker(mockForespoerselRepository, mockMottakRepository)
         mockConsumer.lesMelding(UGYLDIG_FORESPOERSEL_MOTTATT)
 
         verify(exactly = 1) { mockMottakRepository.opprett(any()) }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
-import java.util.UUID
 
 @WithPostgresContainer
 class MeldingTolkerTest {
@@ -113,9 +112,6 @@ class MeldingTolkerTest {
                 navn = PersonNavn(fornavn = "Testfrans", mellomnavn = null, etternavn = "Testesen"),
                 foedselsdato = LocalDate.now().minusYears(1),
             )
-
-        every { service.dialogportenService.opprettNyDialogMedSykmelding(any(), any(), any()) } returns
-            UUID.randomUUID().toString()
 
         every { service.dialogportenService.opprettNyDialogMedSykmelding(any()) } just Runs
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
@@ -34,7 +34,6 @@ import no.nav.helsearbeidsgiver.utils.TestData.FORESPOERSEL_MOTTATT
 import no.nav.helsearbeidsgiver.utils.TestData.SIMBA_PAYLOAD
 import no.nav.helsearbeidsgiver.utils.TestData.SYKMELDING_MOTTATT
 import no.nav.helsearbeidsgiver.utils.TestData.TRENGER_FORESPOERSEL
-import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.buildJournalfoertInntektsmelding
 import no.nav.helsearbeidsgiver.utils.test.json.removeJsonWhitespace
 import org.jetbrains.exposed.sql.Database
@@ -51,7 +50,6 @@ class MeldingTolkerTest {
     private lateinit var repositories: Repositories
     private lateinit var service: Services
     private lateinit var tolkere: Tolkere
-    private lateinit var unleashFeatureToggles: UnleashFeatureToggles
 
     @BeforeAll
     fun setup() {
@@ -81,9 +79,7 @@ class MeldingTolkerTest {
                 pdlService = mockk<PdlService>(),
             )
 
-        unleashFeatureToggles = mockk<UnleashFeatureToggles>(relaxed = true)
-
-        tolkere = configureTolkere(service, repositories, unleashFeatureToggles)
+        tolkere = configureTolkere(service, repositories)
     }
 
     @BeforeEach

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/testcontainer/LpsApiIntegrasjontest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/testcontainer/LpsApiIntegrasjontest.kt
@@ -49,7 +49,7 @@ abstract class LpsApiIntegrasjontest {
             ).init()
         repositories = configureRepositories(db)
         services = configureServices(repositories, mockk(relaxed = true))
-        tolkers = configureTolkere(services, repositories, mockk(relaxed = true))
+        tolkers = configureTolkere(services, repositories)
 
         embeddedServer(
             factory = Netty,


### PR DESCRIPTION
Oppretter dialoger ved å sende meldinger på dialog topic som ny app plukker opp
Fjerner Dialogporten klient kode da dette er flyttet til den andre applikasjonen i repo hag-dialog