### PR TITLE
Endre tilbake til default deployment strategi etter at vi er ferdig med denne rundens databasemigreringer

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -12,8 +12,6 @@ spec:
   replicas:
     max: 2
     min: 2
-  strategy:
-    type: Recreate
   resources:
     requests:
       cpu: "250m"


### PR DESCRIPTION
Default er `RollingUpdate ` https://kubernetes.io/docs/concepts/workloads/controllers/deployment/