### PR TITLE
send securelogs til elastic

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -20,14 +20,15 @@ spec:
     limits:
       memory: "1024Mi"
   observability:
+    logging:
+      destinations:
+        - id: secure_logs
     autoInstrumentation:
       enabled: true
       runtime: java
   prometheus:
     enabled: true
     path: /metrics
-  secureLogs:
-    enabled: true
   kafka:
     pool: nav-dev
   ingresses:

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -35,6 +35,7 @@ spec:
     pool: nav-dev
   ingresses:
     - https://sykepenger-im-lps-api.ekstern.dev.nav.no
+    - https://sykepenger-api.ekstern.dev.nav.no
   image: {{image}}
   port: 8080
   accessPolicy:

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -26,6 +26,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   prometheus:
     enabled: true
     path: /metrics

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -20,6 +20,9 @@ spec:
     limits:
       memory: "1024Mi"
   observability:
+    logging:
+      destinations:
+        - id: secure_logs
     autoInstrumentation:
       enabled: true
       runtime: java
@@ -31,7 +34,7 @@ spec:
   kafka:
     pool: nav-prod
 #  ingresses:
-#    - https://sykepenger-im-lps-api.ekstern.nav.no
+#    - https://sykepenger-api.ekstern.nav.no
   image: {{image}}
   port: 8080
   accessPolicy:


### PR DESCRIPTION
elastic fases ut i år. 
Inntil vi går over til å bruke teamlogs / loki / grafana, enabler vi sending til elastic midlertidig.

Legger også til en ny ingress i dev (fjerner im-lps)