### PR TITLE
Kun lagre de søknadene som skal sendes videre til arbeidsgiver

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/soknad/SoknadTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/soknad/SoknadTolker.kt
@@ -18,7 +18,7 @@ class SoknadTolker(
             sikkerLogger.info(
                 "Mottok søknad med id ${soknadMessage.id}, sykmeldingId ${soknadMessage.sykmeldingId} og sendtNav ${soknadMessage.sendtNav}.",
             )
-            soknadService.lagreSoknad(soknadMessage)
+            soknadService.behandleSoknad(soknadMessage)
         } catch (e: Exception) {
             val errorMsg = "Klarte ikke å lagre søknad om sykepenger!"
             logger.error(errorMsg)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/soknad/SykepengesoknadDTO.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/soknad/SykepengesoknadDTO.kt
@@ -192,7 +192,6 @@ data class SykepengesoknadDTO(
         val kriterieForVisningAvUndersporsmal: VisningskriteriumDTO? = null,
         val svar: List<SvarDTO>? = null,
         val undersporsmal: List<SporsmalDTO>? = null,
-        // val metadata: JsonNode? = null, // TODO: Hva gjør vi med denne?
     )
 
     @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soknad/SoknadService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soknad/SoknadService.kt
@@ -6,16 +6,37 @@ import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 class SoknadService(
     val soknadRepository: SoknadRepository,
 ) {
-    fun lagreSoknad(soknad: SykepengesoknadDTO) {
+    fun behandleSoknad(soknad: SykepengesoknadDTO) {
+        if (!soknad.skalLagresOgSendesTilArbeidsgiver()) {
+            sikkerLogger().info("Søknad med id ${soknad.id} ignoreres fordi den ikke skal lagres og sendes til arbeidsgiver.")
+            return
+        }
+
+        if (soknad.soknadAlleredeLagret()) {
+            sikkerLogger().info("Søknad med id ${soknad.id} ignoreres fordi den allerede er lagret.")
+            return
+        }
+
         try {
             soknadRepository.lagreSoknad(soknad.validerPaakrevdeFelter())
         } catch (e: IllegalArgumentException) {
-            sikkerLogger().error(
+            sikkerLogger().warn(
                 "Ignorerer sykepengesøknad med id ${soknad.id} fordi søknaden mangler et påkrevd felt.",
                 e,
             )
         }
     }
+
+    private fun SykepengesoknadDTO.skalLagresOgSendesTilArbeidsgiver(): Boolean =
+        (
+            erArbeidstakerSoknad() ||
+                erArbeidstakerMedGradertReiseTilskudd() ||
+                erArbeidstakerMedBehandlingsdager()
+
+        ) &&
+            !erEttersendtTilNAV() &&
+            this.status == SykepengesoknadDTO.SoknadsstatusDTO.SENDT &&
+            this.sendtArbeidsgiver != null
 
     private fun SykepengesoknadDTO.validerPaakrevdeFelter(): LagreSoknad =
         LagreSoknad(
@@ -25,4 +46,18 @@ class SoknadService(
             orgnr = requireNotNull(arbeidsgiver?.orgnummer) { "Orgnummer kan ikke være null" },
             sykepengesoknad = this,
         )
+
+    private fun SykepengesoknadDTO.erArbeidstakerSoknad(): Boolean = this.type == SykepengesoknadDTO.SoknadstypeDTO.ARBEIDSTAKERE
+
+    private fun SykepengesoknadDTO.erArbeidstakerMedGradertReiseTilskudd(): Boolean =
+        this.arbeidssituasjon == SykepengesoknadDTO.ArbeidssituasjonDTO.ARBEIDSTAKER &&
+            this.type == SykepengesoknadDTO.SoknadstypeDTO.GRADERT_REISETILSKUDD
+
+    private fun SykepengesoknadDTO.erArbeidstakerMedBehandlingsdager(): Boolean =
+        this.arbeidssituasjon == SykepengesoknadDTO.ArbeidssituasjonDTO.ARBEIDSTAKER &&
+            this.type == SykepengesoknadDTO.SoknadstypeDTO.BEHANDLINGSDAGER
+
+    private fun SykepengesoknadDTO.soknadAlleredeLagret(): Boolean = soknadRepository.hentSoknad(id) != null
+
+    private fun SykepengesoknadDTO.erEttersendtTilNAV() = sendtNav != null && sendtArbeidsgiver?.isBefore(sendtNav) ?: false
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
@@ -159,12 +159,12 @@ class MeldingTolkerTest {
 
     @Test
     fun `SoknadTolker lesMelding klarer å deserialisere soknad`() {
-        every { service.soknadService.lagreSoknad(any()) } just Runs
+        every { service.soknadService.behandleSoknad(any()) } just Runs
         val soknadJson =
             SYKEPENGESOKNAD.removeJsonWhitespace()
         tolkere.soknadTolker.lesMelding(soknadJson)
 
-        verify(exactly = 1) { service.soknadService.lagreSoknad(any()) }
+        verify(exactly = 1) { service.soknadService.behandleSoknad(any()) }
     }
 
     @Test
@@ -178,6 +178,6 @@ class MeldingTolkerTest {
         assertThrows<SerializationException> {
             tolkere.soknadTolker.lesMelding(mockJsonMedArbeidsgiverNull)
         }
-        verify(exactly = 0) { service.soknadService.lagreSoknad(any()) }
+        verify(exactly = 0) { service.soknadService.behandleSoknad(any()) }
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soknad/SoknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soknad/SoknadServiceTest.kt
@@ -37,11 +37,11 @@ class SoknadServiceTest {
     }
 
     @Test
-    fun `lagreSoknad skal lagre søknad`() {
+    fun `behandleSoknad skal lagre søknad`() {
         val soknad =
             soknadMock()
 
-        soknadService.lagreSoknad(soknad)
+        soknadService.behandleSoknad(soknad)
 
         val lagretSoknad =
             transaction(db) { SoknadEntitet.selectAll().firstOrNull()?.getOrNull(sykepengesoknad) }
@@ -50,11 +50,11 @@ class SoknadServiceTest {
     }
 
     @Test
-    fun `lagreSoknad skal _ikke_ lagre søknad dersom den mangler sykmeldingId`() {
+    fun `behandleSoknad skal _ikke_ lagre søknad dersom den mangler sykmeldingId`() {
         val soknad =
             soknadMock().copy(sykmeldingId = null)
 
-        soknadService.lagreSoknad(soknad)
+        soknadService.behandleSoknad(soknad)
 
         val lagretSoknad =
             transaction(db) { SoknadEntitet.selectAll().firstOrNull()?.getOrNull(sykepengesoknad) }
@@ -63,7 +63,7 @@ class SoknadServiceTest {
     }
 
     @Test
-    fun `lagreSoknad skal _ikke_ lagre søknad dersom den mangler orgnr`() {
+    fun `behandleSoknad skal _ikke_ lagre søknad dersom den mangler orgnr`() {
         val soknad = soknadMock()
 
         val soknad1 =
@@ -71,8 +71,8 @@ class SoknadServiceTest {
         val soknad2 =
             soknad.copy(arbeidsgiver = soknad.arbeidsgiver?.copy(orgnummer = null))
 
-        soknadService.lagreSoknad(soknad1)
-        soknadService.lagreSoknad(soknad2)
+        soknadService.behandleSoknad(soknad1)
+        soknadService.behandleSoknad(soknad2)
 
         val lagretSoknad =
             transaction(db) { SoknadEntitet.selectAll().firstOrNull()?.getOrNull(sykepengesoknad) }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soknad/SoknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soknad/SoknadServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.helsearbeidsgiver.soknad
 
 import io.kotest.matchers.shouldBe
 import no.nav.helsearbeidsgiver.config.DatabaseConfig
+import no.nav.helsearbeidsgiver.kafka.soknad.SykepengesoknadDTO
 import no.nav.helsearbeidsgiver.soknad.SoknadEntitet.sykepengesoknad
 import no.nav.helsearbeidsgiver.testcontainer.WithPostgresContainer
 import no.nav.helsearbeidsgiver.utils.TestData.soknadMock
@@ -12,6 +13,8 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.UUID
 
 @WithPostgresContainer
 class SoknadServiceTest {
@@ -37,7 +40,7 @@ class SoknadServiceTest {
     }
 
     @Test
-    fun `behandleSoknad skal lagre søknad`() {
+    fun `skal lagre søknad som skal sendes til arbeidsgiver`() {
         val soknad =
             soknadMock()
 
@@ -50,7 +53,7 @@ class SoknadServiceTest {
     }
 
     @Test
-    fun `behandleSoknad skal _ikke_ lagre søknad dersom den mangler sykmeldingId`() {
+    fun `skal _ikke_ lagre søknad dersom den mangler sykmeldingId`() {
         val soknad =
             soknadMock().copy(sykmeldingId = null)
 
@@ -63,7 +66,7 @@ class SoknadServiceTest {
     }
 
     @Test
-    fun `behandleSoknad skal _ikke_ lagre søknad dersom den mangler orgnr`() {
+    fun `skal _ikke_ lagre søknad dersom den mangler orgnr`() {
         val soknad = soknadMock()
 
         val soknad1 =
@@ -78,5 +81,147 @@ class SoknadServiceTest {
             transaction(db) { SoknadEntitet.selectAll().firstOrNull()?.getOrNull(sykepengesoknad) }
 
         lagretSoknad shouldBe null
+    }
+
+    @Test
+    fun `skal _ikke_ lagre søknad dersom den er en søknadstype som ikke skal sendes til arbeidsgiver`() {
+        val soknad = soknadMock()
+
+        val soknadstyperSomIkkeSkalLagres =
+            SykepengesoknadDTO.SoknadstypeDTO.entries
+                .filterNot {
+                    it == SykepengesoknadDTO.SoknadstypeDTO.ARBEIDSTAKERE ||
+                        it == SykepengesoknadDTO.SoknadstypeDTO.GRADERT_REISETILSKUDD ||
+                        it == SykepengesoknadDTO.SoknadstypeDTO.BEHANDLINGSDAGER
+                }
+
+        val soknaderSomIkkeSkalLagres = soknadstyperSomIkkeSkalLagres.map { soknad.copy(type = it) }
+
+        soknaderSomIkkeSkalLagres.forEach { soknadService.behandleSoknad(it) }
+
+        val lagretSoknad =
+            transaction(db) { SoknadEntitet.selectAll().firstOrNull()?.getOrNull(sykepengesoknad) }
+
+        lagretSoknad shouldBe null
+    }
+
+    @Test
+    fun `skal _ikke_ lagre søknad hvis søknadstype GRADERT_REISETILSKUDD eller BEHANDLINGSDAGER, men ikke arbeidssituasjon ARBEIDSTAKER`() {
+        val soknad = soknadMock()
+
+        val idSomSkalLagres1 = UUID.randomUUID()
+        val idSomSkalLagres2 = UUID.randomUUID()
+
+        val soknaderSomSkalLagres =
+            listOf(
+                soknad.copy(
+                    id = idSomSkalLagres1,
+                    type = SykepengesoknadDTO.SoknadstypeDTO.GRADERT_REISETILSKUDD,
+                    arbeidssituasjon = SykepengesoknadDTO.ArbeidssituasjonDTO.ARBEIDSTAKER,
+                ),
+                soknad.copy(
+                    id = idSomSkalLagres2,
+                    type = SykepengesoknadDTO.SoknadstypeDTO.BEHANDLINGSDAGER,
+                    arbeidssituasjon = SykepengesoknadDTO.ArbeidssituasjonDTO.ARBEIDSTAKER,
+                ),
+            )
+
+        val arbeidssituasjonerSomIkkeSkalLagres =
+            SykepengesoknadDTO.ArbeidssituasjonDTO.entries
+                .filterNot {
+                    it == SykepengesoknadDTO.ArbeidssituasjonDTO.ARBEIDSTAKER
+                }
+
+        val soknaderSomIkkeSkalLagres =
+            arbeidssituasjonerSomIkkeSkalLagres.map {
+                soknad.copy(
+                    id = UUID.randomUUID(),
+                    type = SykepengesoknadDTO.SoknadstypeDTO.GRADERT_REISETILSKUDD,
+                    arbeidssituasjon = it,
+                )
+            } +
+                arbeidssituasjonerSomIkkeSkalLagres.map {
+                    soknad.copy(
+                        id = UUID.randomUUID(),
+                        type = SykepengesoknadDTO.SoknadstypeDTO.BEHANDLINGSDAGER,
+                        arbeidssituasjon = it,
+                    )
+                }
+
+        (soknaderSomSkalLagres + soknaderSomIkkeSkalLagres).forEach { soknadService.behandleSoknad(it) }
+
+        val lagredeSoknader =
+            transaction(db) { SoknadEntitet.selectAll().map { it.getOrNull(sykepengesoknad) } }
+
+        lagredeSoknader.size shouldBe 2
+        lagredeSoknader.map { it?.id }.toSet() shouldBe listOf(idSomSkalLagres1, idSomSkalLagres2).toSet()
+    }
+
+    @Test
+    fun `skal _ikke_ lagre søknad dersom den ettersendt til Nav`() {
+        val soknad = soknadMock()
+
+        val soknadSomIkkeSkalLagres =
+            soknad.copy(sendtArbeidsgiver = LocalDateTime.now().minusDays(1), sendtNav = LocalDateTime.now())
+
+        soknadService.behandleSoknad(soknadSomIkkeSkalLagres)
+
+        val lagretSoknad =
+            transaction(db) { SoknadEntitet.selectAll().firstOrNull()?.getOrNull(sykepengesoknad) }
+
+        lagretSoknad shouldBe null
+    }
+
+    @Test
+    fun `skal _ikke_ lagre søknad dersom statusen er noe annet enn sendt`() {
+        val soknad = soknadMock()
+
+        val statuserSomIkkeSkalLagres =
+            SykepengesoknadDTO.SoknadsstatusDTO.entries.filterNot { it == SykepengesoknadDTO.SoknadsstatusDTO.SENDT }
+
+        val soknaderSomIkkeSkalLagres =
+            statuserSomIkkeSkalLagres.map { soknad.copy(id = UUID.randomUUID(), status = it) }
+
+        soknaderSomIkkeSkalLagres.forEach { soknadService.behandleSoknad(it) }
+
+        val lagretSoknad =
+            transaction(db) { SoknadEntitet.selectAll().firstOrNull()?.getOrNull(sykepengesoknad) }
+
+        lagretSoknad shouldBe null
+    }
+
+    @Test
+    fun `skal _ikke_ lagre søknad dersom feltet sendtArbeidsgiver er null`() {
+        val soknad = soknadMock()
+
+        val soknadSomIkkeSkalLagres =
+            soknad.copy(id = UUID.randomUUID(), sendtArbeidsgiver = null)
+
+        soknadService.behandleSoknad(soknadSomIkkeSkalLagres)
+
+        val lagretSoknad =
+            transaction(db) { SoknadEntitet.selectAll().firstOrNull()?.getOrNull(sykepengesoknad) }
+
+        lagretSoknad shouldBe null
+    }
+
+    @Test
+    fun `skal _ikke_ lagre søknad dersom det allerede finnes en søknad i databasen med den IDen`() {
+        val soknad = soknadMock()
+        val soknadId = UUID.randomUUID()
+
+        val soknadSomSkalLagres = soknad.copy(id = soknadId)
+
+        val soknadSomIkkeSkalLagres =
+            soknad.copy(id = soknadId, fom = soknad.fom?.minusDays(1))
+
+        soknadService.behandleSoknad(soknadSomSkalLagres)
+        soknadService.behandleSoknad(soknadSomIkkeSkalLagres)
+
+        val lagredeSoknader =
+            transaction(db) { SoknadEntitet.selectAll().map { it.getOrNull(sykepengesoknad) } }
+
+        lagredeSoknader.size shouldBe 1
+        lagredeSoknader.first()?.fom shouldBe soknadSomSkalLagres.fom
     }
 }


### PR DESCRIPTION
**Bakgrunn**
Vi lytter nå på søknader som kommer på kafka-topicet `flex.sykepengesoknad`, men det er ikke alle disse som vi skal sende videre til arbeidsgiver.

**Løsning**
Kopier filtreringslogikken fra appen til team Flex (sykepengesoknad-altinn) som velger ut hvilke søknader som skal sendes videre til arbeidsgiver.