### PR TITLE
Oppdaterer søknad som vises til arbeidsgiver

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/soknad/SykepengesoknadDTO.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/soknad/SykepengesoknadDTO.kt
@@ -20,7 +20,7 @@ data class SykepengesoknadDTO(
     val sykmeldingId: UUID? = null,
     val arbeidsgiver: ArbeidsgiverDTO? = null,
     val arbeidssituasjon: ArbeidssituasjonDTO? = null,
-    val korrigerer: String? = null,
+    val korrigerer: UUID? = null, // gjør om til uuid?
     val korrigertAv: String? = null,
     val soktUtenlandsopphold: Boolean? = null,
     val arbeidsgiverForskutterer: ArbeidsgiverForskuttererDTO? = null,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soknad/Sykepengesoknad.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soknad/Sykepengesoknad.kt
@@ -4,7 +4,6 @@ package no.nav.helsearbeidsgiver.soknad
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateTimeSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
@@ -15,7 +14,7 @@ import java.util.UUID
 /**
  * Datamodell for Sykepengesøknad.
  * Inneholder bare felter som skal vises til arbeidsgiver.
- * Er hentet fra flex sin applikasjon for å sende søknader til arbeidsgiver via altinn
+ * Er basert på modellen i flex sin applikasjon for å sende søknader til arbeidsgiver via altinn
  * https://github.com/navikt/sykepengesoknad-altinn/tree/main/src/main/kotlin/no/nav/syfo/domain/soknad
  */
 
@@ -25,31 +24,18 @@ data class Sykepengesoknad(
     val fnr: String,
     val sykmeldingId: UUID? = null,
     val type: Soknadstype,
-    // val status: Soknadsstatus,
     val fom: LocalDate? = null,
     val tom: LocalDate? = null,
-    val startSykeforlop: LocalDate? = null,
     val arbeidGjenopptatt: LocalDate? = null,
-    // val opprettet: LocalDateTime? = null,
+    val opprettet: LocalDateTime? = null,
     val sendtNav: LocalDateTime? = null,
-    val sendtArbeidsgiver: LocalDateTime? = null,
-    val sykmeldingSkrevet: LocalDateTime? = null,
     val arbeidsgiver: Arbeidsgiver,
-    val arbeidsgiverForskutterer: ArbeidsverForskutterer,
     val soktUtenlandsopphold: Boolean? = null,
-    val korrigerer: String? = null,
-    // val korrigertAv: String? = null,
+    val korrigerer: UUID? = null,
     // val arbeidssituasjon: Arbeidssituasjon? = null,
     val soknadsperioder: List<Soknadsperiode> = arrayListOf(),
     // val behandlingsdager: List<LocalDate> = arrayListOf(),
-    val egenmeldinger: List<Periode> = arrayListOf(),
-    val fravarForSykmeldingen: List<Periode> = arrayListOf(),
-    // val papirsykmeldinger: List<Periode> = arrayListOf(),
     val fravar: List<Fravar> = arrayListOf(),
-    // val andreInntektskilder: List<Inntektskilde> = arrayListOf(),
-    val sporsmal: List<Sporsmal> = arrayListOf(),
-    val avsendertype: Avsendertype? = null,
-    // val ettersending: Boolean = false,
 ) {
     @Serializable
     enum class Soknadstype {
@@ -60,42 +46,11 @@ data class Sykepengesoknad(
         GRADERT_REISETILSKUDD,
     }
 
-    /*@Serializable
-    enum class Soknadsstatus {
-        NY,
-        SENDT,
-        FREMTIDIG,
-        UTKAST_TIL_KORRIGERING,
-        KORRIGERT,
-        AVBRUTT,
-        SLETTET,
-    }*/
-
     @Serializable
     data class Arbeidsgiver(
         val navn: String,
-        val orgnummer: String,
+        val orgnr: String,
     )
-
-    @Serializable
-    enum class ArbeidsverForskutterer {
-        JA,
-        NEI,
-        VET_IKKE,
-        IKKE_SPURT, // Default verdi når arbeidsgiverForskutterer ikke er satt
-    }
-
-    /*@Serializable
-    enum class Arbeidssituasjon(
-        val value: String,
-    ) {
-        NAERINGSDRIVENDE("selvstendig næringsdrivende"),
-        FRILANSER("frilanser"),
-        ARBEIDSTAKER("arbeidstaker"),
-        ;
-
-        override fun toString() = value
-    }*/
 
     @Serializable
     data class Soknadsperiode(
@@ -117,27 +72,6 @@ data class Sykepengesoknad(
         REISETILSKUDD,
     }
 
-    /*@Serializable
-    data class Inntektskilde(
-        val type: Inntektskildetype,
-        val sykmeldt: Boolean?,
-    )
-
-    @Serializable
-    enum class Inntektskildetype {
-        ANDRE_ARBEIDSFORHOLD,
-        FRILANSER,
-        SELVSTENDIG_NARINGSDRIVENDE,
-        SELVSTENDIG_NARINGSDRIVENDE_DAGMAMMA,
-        JORDBRUKER_FISKER_REINDRIFTSUTOVER,
-        ANNET,
-        FOSTERHJEMGODTGJORELSE,
-        OMSORGSLONN,
-        ARBEIDSFORHOLD,
-        FRILANSER_SELVSTENDIG,
-        STYREVERV,
-    }*/
-
     @Serializable
     data class Fravar(
         val fom: LocalDate,
@@ -149,69 +83,9 @@ data class Sykepengesoknad(
     enum class Fravarstype {
         FERIE,
         PERMISJON,
-        UTLANDSOPPHOLD,
+        UTLANDSOPPHOLD, // Skal vi fjerne denne?
         UTDANNING_FULLTID,
         UTDANNING_DELTID,
-        UKJENT,
-    }
-
-    @Serializable
-    enum class Avsendertype {
-        BRUKER,
-        SYSTEM,
-    }
-
-    @Serializable
-    data class Sporsmal(
-        val id: String? = null,
-        val tag: String? = null,
-        val sporsmalstekst: String? = null,
-        val undertekst: String? = null,
-        val svartype: Svartype? = null,
-        val min: String? = null,
-        val max: String? = null,
-        val kriterieForVisningAvUndersporsmal: Visningskriterium? = null,
-        val svar: List<Svar> = arrayListOf(),
-        val undersporsmal: List<Sporsmal> = arrayListOf(),
-    )
-
-    @Serializable
-    enum class Visningskriterium {
-        JA,
-        NEI,
-        CHECKED,
-    }
-
-    @Serializable
-    data class Svar(
-        val verdi: String? = null,
-    )
-
-    @Serializable
-    enum class Svartype {
-        JA_NEI,
-        CHECKBOX,
-        CHECKBOX_GRUPPE,
-        CHECKBOX_PANEL,
-        DATO,
-        PERIODE,
-        PERIODER,
-        TIMER,
-        FRITEKST,
-        LAND,
-        IKKE_RELEVANT,
-        PROSENT,
-        RADIO_GRUPPE,
-        RADIO_GRUPPE_TIMER_PROSENT,
-        RADIO_GRUPPE_UKEKALENDER,
-        RADIO,
-        TALL,
-        INFO_BEHANDLINGSDAGER,
-        KVITTERING,
-        DATOER,
-        BELOP,
-        KILOMETER,
-        BEKREFTELSESPUNKTER,
-        OPPSUMMERING,
+        UKJENT, // Skal vi fjerne denne?
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/SoknadUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/SoknadUtils.kt
@@ -13,76 +13,23 @@ fun SykepengesoknadDTO.konverter(): Sykepengesoknad =
         sykmeldingId = this.sykmeldingId,
         arbeidsgiver = konverter(this.arbeidsgiver),
         // arbeidssituasjon = enumValueOrNull(this.arbeidssituasjon!!.name),
-        // korrigertAv = this.korrigertAv,
         korrigerer = this.korrigerer,
         soktUtenlandsopphold = this.soktUtenlandsopphold,
-        arbeidsgiverForskutterer = this.arbeidsgiverForskutterer.tilArbeidsgiverForskutterer(),
         fom = this.fom,
         tom = this.tom,
-        startSykeforlop = this.startSyketilfelle,
         arbeidGjenopptatt = this.arbeidGjenopptatt,
-        sykmeldingSkrevet = this.sykmeldingSkrevet,
-        // opprettet = this.opprettet,
+        opprettet = this.opprettet,
         sendtNav = this.sendtNav,
-        sendtArbeidsgiver = this.sendtArbeidsgiver,
         // behandlingsdager = this.behandlingsdager ?: emptyList(), TODO: skal vi ta med denne videre til ag?
-        egenmeldinger =
-            this.egenmeldinger
-                ?.map { konverter(it) }
-                .orEmpty(), // TODO: Skal vi ta med egenmeldinger fra sykmeldingen
-        fravarForSykmeldingen =
-            this.fravarForSykmeldingen
-                ?.map { konverter(it) }
-                .orEmpty(),
-        /*papirsykmeldinger =
-            this.papirsykmeldinger
-                ?.map { konverter(it) }
-                .orEmpty(),*/
         fravar =
             this.fravar
                 ?.map { konverter(it) }
                 .orEmpty(),
-        /*andreInntektskilder =
-            this.andreInntektskilder
-                ?.map { konverter(it) }
-                .orEmpty(),*/
         soknadsperioder =
             this.soknadsperioder
                 ?.map { konverter(it) }
                 .orEmpty(),
-        sporsmal =
-            this.sporsmal
-                ?.map { konverter(it) }
-                .orEmpty(),
-        // ettersending = this.ettersending,
     )
-
-private fun konverter(svarDTO: SykepengesoknadDTO.SvarDTO): Sykepengesoknad.Svar =
-    Sykepengesoknad.Svar(
-        verdi = svarDTO.verdi,
-    )
-
-private fun konverter(sporsmalDTO: SykepengesoknadDTO.SporsmalDTO): Sykepengesoknad.Sporsmal {
-    requireNotNull(sporsmalDTO.svartype)
-    return Sykepengesoknad.Sporsmal(
-        id = sporsmalDTO.id,
-        tag = sporsmalDTO.tag,
-        sporsmalstekst = sporsmalDTO.sporsmalstekst,
-        undertekst = sporsmalDTO.undertekst,
-        svartype = Sykepengesoknad.Svartype.valueOf(sporsmalDTO.svartype.name),
-        min = sporsmalDTO.min,
-        max = sporsmalDTO.max,
-        kriterieForVisningAvUndersporsmal = enumValueOrNull(sporsmalDTO.kriterieForVisningAvUndersporsmal?.name),
-        svar =
-            sporsmalDTO.svar
-                ?.map { konverter(it) }
-                .orEmpty(),
-        undersporsmal =
-            sporsmalDTO.undersporsmal
-                ?.map { konverter(it) }
-                .orEmpty(),
-    )
-}
 
 private fun konverter(soknadPeriodeDTO: SykepengesoknadDTO.SoknadsperiodeDTO): Sykepengesoknad.Soknadsperiode {
     requireNotNull(soknadPeriodeDTO.fom)
@@ -106,7 +53,7 @@ private fun konverter(arbeidsgiverDTO: SykepengesoknadDTO.ArbeidsgiverDTO?): Syk
     requireNotNull(arbeidsgiverDTO.orgnummer)
     return Sykepengesoknad.Arbeidsgiver(
         navn = arbeidsgiverDTO.navn,
-        orgnummer = arbeidsgiverDTO.orgnummer,
+        orgnr = arbeidsgiverDTO.orgnummer,
     )
 }
 
@@ -129,21 +76,7 @@ private fun konverter(fravarDTO: SykepengesoknadDTO.FravarDTO): Sykepengesoknad.
     )
 }
 
-/*private fun konverter(inntektskildeDTO: SykepengesoknadDTO.InntektskildeDTO): Sykepengesoknad.Inntektskilde =
-    Sykepengesoknad.Inntektskilde(
-        type = Sykepengesoknad.Inntektskildetype.valueOf(inntektskildeDTO.type!!.name),
-        sykmeldt = inntektskildeDTO.sykmeldt,
-    )*/
-
 private inline fun <reified T : Enum<*>> enumValueOrNull(name: String?): T? = T::class.java.enumConstants.firstOrNull { it.name == name }
-
-private fun SykepengesoknadDTO.ArbeidsgiverForskuttererDTO?.tilArbeidsgiverForskutterer(): Sykepengesoknad.ArbeidsverForskutterer =
-    when (this) {
-        SykepengesoknadDTO.ArbeidsgiverForskuttererDTO.JA -> Sykepengesoknad.ArbeidsverForskutterer.JA
-        SykepengesoknadDTO.ArbeidsgiverForskuttererDTO.NEI -> Sykepengesoknad.ArbeidsverForskutterer.NEI
-        SykepengesoknadDTO.ArbeidsgiverForskuttererDTO.VET_IKKE -> Sykepengesoknad.ArbeidsverForskutterer.VET_IKKE
-        else -> Sykepengesoknad.ArbeidsverForskutterer.IKKE_SPURT
-    }
 
 private val whitelistetHovedsporsmal =
     listOf(


### PR DESCRIPTION
- Fjerner `sporsmal` fra json fordi dette ikke er relevant for arbeidsgiver
- Legger til et `opprettet` felt fordi `sendtTilArbeidsgiver` fjernes
- Fjerner `sentTilArbeidsgiver` fordi vi ikke egentlig sender til arbeidsgiver, ag henter den selv. Den erstattes også med nytt felt opprett dato
- Fjerner `startSykeforlop` fordi denne er satt av legen og er ikke pålitelig nok
-  Fjerner `arbeidsgiverForskutterer`, bruker blir aldri spurt om dette blir alltid satt til IKKE_SPURT
- Fjerner `sykmeldingSkrevet` fordi informasjonen kan hentes fra sykmeldingen
- Fjerner `egenmelding` feltet fordi Dag tør :) og vi ønsker å diskutere med flex hvor egenmeldingen bør høre til(søknad eller sykmelding)
- Fjerner `fravarForSykmeldingen` fordi det ikke trengs hvis vi ikke har egenmeldinger heller.
- Fjerner `avsenderType` fordi det bare blir satt til system når noen er død