### PR TITLE
Ikke logg orgnr til åpne logger

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingService.kt
@@ -73,7 +73,7 @@ class InntektsmeldingService(
             sikkerLogger().info("InnsendtInntektsmelding ${im.type.id} lagret")
         }.onFailure {
             sikkerLogger().warn("Feil ved oppretting av inntektsmelding for orgnr: ${im.avsender.orgnr.verdi}", it)
-            throw Exception("Feil ved oppretting av inntektsmelding for orgnr: ${im.avsender.orgnr.verdi}", it)
+            throw Exception("Feil ved oppretting av inntektsmelding med id: ${im.id}", it)
         }
     }
 


### PR DESCRIPTION
Vi snublet over denne da vi feilsøke i LPS-apiet. Exceptionen blir plukket opp og logget et par hakk lengre opp. Endrer til å heller logge IDen.