### PR TITLE
Send forespørsel om inntektsmelding til Dialogporten

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
@@ -102,6 +102,7 @@ fun configureTolkere(
         ForespoerselTolker(
             forespoerselRepository = repositories.forespoerselRepository,
             mottakRepository = repositories.mottakRepository,
+            dialogportenService = services.dialogportenService,
         )
     val sykmeldingTolker =
         SykmeldingTolker(
@@ -174,6 +175,7 @@ fun configureServices(
     val dialogportenService =
         DialogportenService(
             dialogProducer = dialogProducer,
+            soeknadRepository = repositories.soeknadRepository,
             unleashFeatureToggles = unleashFeatureToggles,
         )
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogMelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogMelding.kt
@@ -34,8 +34,8 @@ data class DialogSykepengesoeknad(
 ) : DialogMelding()
 
 @Serializable
-@SerialName("Inntektsmeldingforespoersel")
-data class DialogInntektsmeldingforespoersel(
+@SerialName("Inntektsmeldingsforespoersel")
+data class DialogInntektsmeldingsforespoersel(
     val forespoerselId: UUID,
     val sykmeldingId: UUID,
     val orgnr: Orgnr,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogMelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogMelding.kt
@@ -32,3 +32,11 @@ data class DialogSykepengesoeknad(
     val sykmeldingId: UUID,
     val orgnr: Orgnr,
 ) : DialogMelding()
+
+@Serializable
+@SerialName("Inntektsmeldingforespoersel")
+data class DialogInntektsmeldingforespoersel(
+    val forespoerselId: UUID,
+    val sykmeldingId: UUID,
+    val orgnr: Orgnr,
+) : DialogMelding()

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenService.kt
@@ -39,9 +39,9 @@ class DialogportenService(
         }
     }
 
-    fun oppdaterDialogMedInntektsmeldingforespoersel(forespoersel: ForespoerselDokument) {
+    fun oppdaterDialogMedInntektsmeldingsforespoersel(forespoersel: ForespoerselDokument) {
         val orgnr = Orgnr(forespoersel.orgnr)
-        if (unleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingforespoersel(orgnr)) {
+        if (unleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingsforespoersel(orgnr)) {
             val sykmeldingIder =
                 soeknadRepository
                     .hentSoeknaderMedVedtaksperiodeId(forespoersel.vedtaksperiodeId)
@@ -71,7 +71,7 @@ class DialogportenService(
                 }
 
             dialogProducer.send(
-                DialogInntektsmeldingforespoersel(
+                DialogInntektsmeldingsforespoersel(
                     forespoerselId = forespoersel.forespoerselId,
                     sykmeldingId = sykmeldingId,
                     orgnr = orgnr,
@@ -79,11 +79,11 @@ class DialogportenService(
             )
 
             logger.info(
-                "Sendte melding til hag-dialog for inntektsmeldingforespørsel med id: ${forespoersel.forespoerselId}, sykmeldingId: ${forespoersel.forespoerselId}.",
+                "Sendte melding til hag-dialog for inntektsmeldingsforespørsel med id: ${forespoersel.forespoerselId}, sykmeldingId: ${forespoersel.forespoerselId}.",
             )
         } else {
             logger.info(
-                "Sendte _ikke_ melding til hag-dialog for inntektsmeldingforespørsel med id: ${forespoersel.forespoerselId}, på fordi feature toggle er av.",
+                "Sendte _ikke_ melding til hag-dialog for inntektsmeldingsforespørsel med id: ${forespoersel.forespoerselId}, på fordi feature toggle er av.",
             )
         }
     }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenService.kt
@@ -1,10 +1,14 @@
 package no.nav.helsearbeidsgiver.dialogporten
 
+import no.nav.helsearbeidsgiver.forespoersel.ForespoerselDokument
+import no.nav.helsearbeidsgiver.soeknad.SoeknadRepository
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.logger
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 
 class DialogportenService(
     val dialogProducer: DialogProducer,
+    val soeknadRepository: SoeknadRepository,
     val unleashFeatureToggles: UnleashFeatureToggles,
 ) {
     private val logger = logger()
@@ -30,7 +34,56 @@ class DialogportenService(
             )
         } else {
             logger.info(
-                "Sendte _ikke_ melding til hag-dialog for sykepengesøknad med søknadId: ${soeknad.soeknadId}, sykmeldingId: ${soeknad.sykmeldingId}, på fordi feature toggle er av.",
+                "Sendte _ikke_ melding til hag-dialog for sykepengesøknad med søknadId: ${soeknad.soeknadId}, sykmeldingId: ${soeknad.sykmeldingId}, fordi feature toggle er av.",
+            )
+        }
+    }
+
+    fun oppdaterDialogMedInntektsmeldingforespoersel(forespoersel: ForespoerselDokument) {
+        val orgnr = Orgnr(forespoersel.orgnr)
+        if (unleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingforespoersel(orgnr)) {
+            val sykmeldingIder =
+                soeknadRepository
+                    .hentSoeknaderMedVedtaksperiodeId(forespoersel.vedtaksperiodeId)
+                    .sortedByDescending { it.sendtArbeidsgiver }
+                    .sortedByDescending { it.sendtNav }
+                    .mapNotNull { it.sykmeldingId }
+
+            val sykmeldingId =
+                when {
+                    sykmeldingIder.isEmpty() -> {
+                        logger.warn(
+                            "Fant ingen sykmeldinger for vedtaksperiodeId ${forespoersel.vedtaksperiodeId}. " +
+                                "Kan derfor ikke produsere dialogmelding til hag-dialog.",
+                        )
+                        return
+                    }
+
+                    sykmeldingIder.toSet().size > 1 -> {
+                        logger.warn(
+                            "Fant ${sykmeldingIder.size} sykmeldinger med IDer $sykmeldingIder for " +
+                                "vedtaksperiodeId ${forespoersel.vedtaksperiodeId}. Bruker den nyeste søknaden.",
+                        )
+                        sykmeldingIder.first()
+                    }
+
+                    else -> sykmeldingIder.first()
+                }
+
+            dialogProducer.send(
+                DialogInntektsmeldingforespoersel(
+                    forespoerselId = forespoersel.forespoerselId,
+                    sykmeldingId = sykmeldingId,
+                    orgnr = orgnr,
+                ),
+            )
+
+            logger.info(
+                "Sendte melding til hag-dialog for inntektsmeldingforespørsel med id: ${forespoersel.forespoerselId}, sykmeldingId: ${forespoersel.forespoerselId}.",
+            )
+        } else {
+            logger.info(
+                "Sendte _ikke_ melding til hag-dialog for inntektsmeldingforespørsel med id: ${forespoersel.forespoerselId}, på fordi feature toggle er av.",
             )
         }
     }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenService.kt
@@ -41,8 +41,7 @@ class DialogportenService(
     }
 
     fun oppdaterDialogMedInntektsmeldingsforespoersel(forespoersel: ForespoerselDokument) {
-        val orgnr = Orgnr(forespoersel.orgnr)
-        if (unleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingsforespoersel(orgnr)) {
+        if (unleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingsforespoersel(orgnr = Orgnr(forespoersel.orgnr))) {
             val sykmeldingId = hentSykmeldingId(forespoersel.vedtaksperiodeId)
 
             if (sykmeldingId == null) {
@@ -57,7 +56,7 @@ class DialogportenService(
                 DialogInntektsmeldingsforespoersel(
                     forespoerselId = forespoersel.forespoerselId,
                     sykmeldingId = sykmeldingId,
-                    orgnr = orgnr,
+                    orgnr = Orgnr(forespoersel.orgnr),
                 ),
             )
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenService.kt
@@ -61,11 +61,11 @@ class DialogportenService(
             )
 
             logger.info(
-                "Sendte melding til hag-dialog for inntektsmeldingsforespørsel med id: ${forespoersel.forespoerselId}, sykmeldingId: ${forespoersel.forespoerselId}.",
+                "Sendte melding til hag-dialog for inntektsmeldingsforespørsel med id: ${forespoersel.forespoerselId}, sykmeldingId: $sykmeldingId.",
             )
         } else {
             logger.info(
-                "Sendte _ikke_ melding til hag-dialog for inntektsmeldingsforespørsel med id: ${forespoersel.forespoerselId}, på fordi feature toggle er av.",
+                "Sendte _ikke_ melding til hag-dialog for inntektsmeldingsforespørsel med id: ${forespoersel.forespoerselId}, fordi feature toggle er av.",
             )
         }
     }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenService.kt
@@ -74,9 +74,11 @@ class DialogportenService(
         val sykmeldingIder =
             soeknadRepository
                 .hentSoeknaderMedVedtaksperiodeId(vedtaksperiodeId)
-                .sortedByDescending { it.sendtArbeidsgiver }
-                .sortedByDescending { it.sendtNav }
-                .mapNotNull { it.sykmeldingId }
+                .sortedByDescending { soeknad ->
+                    soeknad.sendtNav
+                        ?: soeknad.sendtArbeidsgiver
+                        ?: null.also { logger.warn("Sykepengesøknad ${soeknad.id} har hverken sendtNav eller sendtArbeidsgiver.") }
+                }.mapNotNull { it.sykmeldingId }
 
         if (sykmeldingIder.toSet().size > 1) {
             logger.warn(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/ForespoerselTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/ForespoerselTolker.kt
@@ -53,7 +53,7 @@ class ForespoerselTolker(
                                 payload = forespoersel,
                             )
                             mottakRepository.opprett(ExposedMottak(melding))
-                            dialogportenService.oppdaterDialogMedInntektsmeldingforespoersel(forespoersel)
+                            dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(forespoersel)
                         } catch (e: Exception) {
                             rollback()
                             logger.error("Klarte ikke å lagre forespørsel i database: $forespoerselId")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/UnleashFeatureToggles.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/UnleashFeatureToggles.kt
@@ -41,6 +41,13 @@ class UnleashFeatureToggles(
             false,
         )
 
+    fun skalOppdatereDialogVedMottattInntektsmeldingforespoersel(orgnr: Orgnr): Boolean =
+        unleashClient.isEnabled(
+            "forespor-inntektsmelding-via-dialogporten",
+            UnleashContext.builder().addProperty("orgnr", orgnr.toString()).build(),
+            false,
+        )
+
     fun skalSendeApiInnsendteImerTilSimba(): Boolean =
         unleashClient.isEnabled(
             "send-api-innsendte-imer-til-simba",

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/UnleashFeatureToggles.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/UnleashFeatureToggles.kt
@@ -41,7 +41,7 @@ class UnleashFeatureToggles(
             false,
         )
 
-    fun skalOppdatereDialogVedMottattInntektsmeldingforespoersel(orgnr: Orgnr): Boolean =
+    fun skalOppdatereDialogVedMottattInntektsmeldingsforespoersel(orgnr: Orgnr): Boolean =
         unleashClient.isEnabled(
             "forespor-inntektsmelding-via-dialogporten",
             UnleashContext.builder().addProperty("orgnr", orgnr.toString()).build(),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
@@ -123,19 +123,19 @@ class DialogportenServiceTest {
     }
 
     @Test
-    fun `dialogportenservice kaller dialogProducer ved mottatt inntektsmeldingforespørsel`() {
+    fun `dialogportenservice kaller dialogProducer ved mottatt inntektsmeldingsforespørsel`() {
         val orgnr = Orgnr.genererGyldig()
         val forespoerselDokument = forespoerselDokument(orgnr.toString(), Fnr.genererGyldig().toString())
         val soeknad = soeknadMock()
 
         coEvery { mockDialogProducer.send(any()) } just Runs
-        every { mockUnleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingforespoersel(orgnr) } returns true
+        every { mockUnleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingsforespoersel(orgnr) } returns true
         every { mockSoeknadRepository.hentSoeknaderMedVedtaksperiodeId(any()) } returns listOf(soeknad)
 
-        dialogportenService.oppdaterDialogMedInntektsmeldingforespoersel(forespoerselDokument)
+        dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(forespoerselDokument)
 
         val forventetDialogMelding =
-            DialogInntektsmeldingforespoersel(
+            DialogInntektsmeldingsforespoersel(
                 forespoerselId = forespoerselDokument.forespoerselId,
                 sykmeldingId = requireNotNull(soeknad.sykmeldingId),
                 orgnr = orgnr,
@@ -147,12 +147,12 @@ class DialogportenServiceTest {
     }
 
     @Test
-    fun `dialogportenservice kaster feil dersom opprettelse av dialog går galt ved mottatt inntektsmeldingforespørsel`() {
+    fun `dialogportenservice kaster feil dersom opprettelse av dialog går galt ved mottatt inntektsmeldingsforespørsel`() {
         val orgnr = Orgnr.genererGyldig()
         val forespoerselDokument = forespoerselDokument(orgnr.toString(), Fnr.genererGyldig().toString())
         val soeknad = soeknadMock()
 
-        every { mockUnleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingforespoersel(orgnr) } returns true
+        every { mockUnleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingsforespoersel(orgnr) } returns true
         every { mockSoeknadRepository.hentSoeknaderMedVedtaksperiodeId(any()) } returns listOf(soeknad)
         coEvery {
             mockDialogProducer.send(
@@ -161,21 +161,21 @@ class DialogportenServiceTest {
         } throws SerializationException("Noe gikk galt")
 
         shouldThrowExactly<SerializationException> {
-            dialogportenService.oppdaterDialogMedInntektsmeldingforespoersel(
+            dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(
                 forespoerselDokument,
             )
         }
     }
 
     @Test
-    fun ` kaller _ikke_ dialogProducer dersom feature toggle for dialogutsending er skrudd av ved mottatt inntektsmeldingforespørsel`() {
+    fun ` kaller _ikke_ dialogProducer dersom feature toggle for dialogutsending er skrudd av ved mottatt inntektsmeldingsforespørsel`() {
         val orgnr = Orgnr.genererGyldig()
         val forespoerselDokument = forespoerselDokument(orgnr.toString(), Fnr.genererGyldig().toString())
 
         coEvery { mockDialogProducer.send(any()) } just Runs
-        every { mockUnleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingforespoersel(orgnr) } returns false
+        every { mockUnleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingsforespoersel(orgnr) } returns false
 
-        dialogportenService.oppdaterDialogMedInntektsmeldingforespoersel(forespoerselDokument)
+        dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(forespoerselDokument)
 
         verify(exactly = 0) {
             mockDialogProducer.send(any())
@@ -188,10 +188,10 @@ class DialogportenServiceTest {
         val forespoerselDokument = forespoerselDokument(orgnr.toString(), Fnr.genererGyldig().toString())
 
         coEvery { mockDialogProducer.send(any()) } just Runs
-        every { mockUnleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingforespoersel(orgnr) } returns true
+        every { mockUnleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingsforespoersel(orgnr) } returns true
         every { mockSoeknadRepository.hentSoeknaderMedVedtaksperiodeId(any()) } returns emptyList()
 
-        dialogportenService.oppdaterDialogMedInntektsmeldingforespoersel(forespoerselDokument)
+        dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(forespoerselDokument)
 
         verify(exactly = 0) {
             mockDialogProducer.send(any())
@@ -199,7 +199,7 @@ class DialogportenServiceTest {
     }
 
     @Test
-    fun `dialogportenservice kaller dialogProducer med sykmeldingIden basert på nyeste søknad ved mottatt inntektsmeldingforespørsel`() {
+    fun `dialogportenservice kaller dialogProducer med sykmeldingIden basert på nyeste søknad ved mottatt inntektsmeldingsforespørsel`() {
         val orgnr = Orgnr.genererGyldig()
         val forespoerselDokument = forespoerselDokument(orgnr.toString(), Fnr.genererGyldig().toString())
         val soeknadEldre = soeknadMock()
@@ -212,17 +212,17 @@ class DialogportenServiceTest {
             )
 
         coEvery { mockDialogProducer.send(any()) } just Runs
-        every { mockUnleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingforespoersel(orgnr) } returns true
+        every { mockUnleashFeatureToggles.skalOppdatereDialogVedMottattInntektsmeldingsforespoersel(orgnr) } returns true
         every { mockSoeknadRepository.hentSoeknaderMedVedtaksperiodeId(any()) } returns
             listOf(
                 soeknadEldre,
                 soeknadNyere,
             )
 
-        dialogportenService.oppdaterDialogMedInntektsmeldingforespoersel(forespoerselDokument)
+        dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(forespoerselDokument)
 
         val forventetDialogMelding =
-            DialogInntektsmeldingforespoersel(
+            DialogInntektsmeldingsforespoersel(
                 forespoerselId = forespoerselDokument.forespoerselId,
                 sykmeldingId = requireNotNull(soeknadNyere.sykmeldingId),
                 orgnr = orgnr,

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
@@ -168,7 +168,7 @@ class DialogportenServiceTest {
     }
 
     @Test
-    fun `kaller _ikke_ dialogProducer dersom feature toggle for dialogutsending er skrudd av ved mottatt inntektsmeldingsforespørsel`() {
+    fun `kaller _ikke_ dialogProducer ved mottatt inntektsmeldingsforespørsel dersom feature toggle for dialogutsending er skrudd av`() {
         val orgnr = Orgnr.genererGyldig()
         val forespoerselDokument = forespoerselDokument(orgnr.toString(), Fnr.genererGyldig().toString())
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenServiceTest.kt
@@ -110,7 +110,7 @@ class DialogportenServiceTest {
     }
 
     @Test
-    fun `dialogportenservice kaller _ikke_ dialogProducer dersom feature toggle for dialogutsending er skrudd av ved mottattt søknad`() {
+    fun `dialogportenservice kaller _ikke_ dialogProducer dersom feature toggle for dialogutsending er skrudd av ved mottatt søknad`() {
         val dialogMelding = genererDialogSykepengesoeknad()
         coEvery { mockDialogProducer.send(any()) } just Runs
         every { mockUnleashFeatureToggles.skalOppdatereDialogVedMottattSoeknad(dialogMelding.orgnr) } returns false
@@ -168,7 +168,7 @@ class DialogportenServiceTest {
     }
 
     @Test
-    fun ` kaller _ikke_ dialogProducer dersom feature toggle for dialogutsending er skrudd av ved mottatt inntektsmeldingsforespørsel`() {
+    fun `kaller _ikke_ dialogProducer dersom feature toggle for dialogutsending er skrudd av ved mottatt inntektsmeldingsforespørsel`() {
         val orgnr = Orgnr.genererGyldig()
         val forespoerselDokument = forespoerselDokument(orgnr.toString(), Fnr.genererGyldig().toString())
 
@@ -202,8 +202,8 @@ class DialogportenServiceTest {
     fun `dialogportenservice kaller dialogProducer med sykmeldingIden basert på nyeste søknad ved mottatt inntektsmeldingsforespørsel`() {
         val orgnr = Orgnr.genererGyldig()
         val forespoerselDokument = forespoerselDokument(orgnr.toString(), Fnr.genererGyldig().toString())
-        val soeknadEldre = soeknadMock()
 
+        val soeknadEldre = soeknadMock()
         val soeknadNyere =
             soeknadMock().copy(
                 sykmeldingId = UUID.randomUUID(),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ApplicationTest.kt
@@ -219,9 +219,10 @@ class ApplicationTest : LpsApiIntegrasjontest() {
 
         val forespoerselMottattJson = buildForespoerselMottattJson(forespoerselId = forespoerselId.toString())
         val priMessage = jsonMapper.decodeFromString<PriMessage>(forespoerselMottattJson)
-        if (priMessage.forespoersel != null) {
+        val forespoersel = priMessage.forespoersel
+        if (forespoersel != null) {
             services.forespoerselService.lagreNyForespoersel(
-                forespoersel = priMessage.forespoersel,
+                forespoersel = forespoersel,
             )
             services.forespoerselService.settBesvart(forespoerselId)
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ApplicationTest.kt
@@ -85,19 +85,24 @@ class ApplicationTest : LpsApiIntegrasjontest() {
         val vedtaksperiodeId = UUID.fromString("3e377f98-1801-4fd2-8d14-cf95d2b831fa")
         val soeknadRecord = ProducerRecord("flex.sykepengesoknad", "key", TestData.SYKEPENGESOEKNAD)
         val sisRecord = ProducerRecord("tbd.sis", "key", TestData.STATUS_I_SPLEIS_MELDING)
+
         Producer.sendMelding(soeknadRecord)
-        // Sikre at søknaden er lagret før sis melding blir skrevet til kafka
-        repeat(5) {
+        Producer.sendMelding(sisRecord)
+
+        // Sikre at søknaden og status i speil er lagret før vi sjekker koblingen mellom søknad og vedtaksperiode
+        var antallRetries = 0
+        while (antallRetries < 5) {
             val soeknad = repositories.soeknadRepository.hentSoeknad(soeknadId)
-            if (soeknad != null) {
-                return
+            val soeknadIder = repositories.statusISpeilRepository.hentSoeknadIderForVedtaksperiodeId(vedtaksperiodeId)
+            if (soeknad != null && soeknadIder.isNotEmpty()) {
+                break
             } else {
                 Thread.sleep(100)
-                return@repeat
+                antallRetries++
             }
         }
-        Producer.sendMelding(sisRecord)
-        val soeknadListe = repositories.soeknadRepository.hentSoeknaderMedVedtaksperiodeId(vedtaksperiodeId).map { it.id }
+        val soeknadListe =
+            repositories.soeknadRepository.hentSoeknaderMedVedtaksperiodeId(vedtaksperiodeId).map { it.id }
         soeknadListe shouldBe listOf(soeknadId)
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ForespoerselIT.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ForespoerselIT.kt
@@ -70,6 +70,7 @@ class ForespoerselIT {
             ForespoerselTolker(
                 forespoerselRepository = repositories.forespoerselRepository,
                 mottakRepository = repositories.mottakRepository,
+                dialogportenService = dialogportenService,
             )
     }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/KafkaCommitOffsetTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/KafkaCommitOffsetTest.kt
@@ -50,6 +50,7 @@ class KafkaCommitOffsetTest {
                 ForespoerselTolker(
                     mockk(),
                     mockk(),
+                    mockk(),
                 ),
             )
         val topicPartition = TopicPartition("test", 0)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/KafkaErrorHandlingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/KafkaErrorHandlingTest.kt
@@ -40,7 +40,12 @@ class KafkaErrorHandlingTest {
                 System.getProperty("database.password"),
             ).init()
         forespoerselRepository = ForespoerselRepository(db)
-        forespoerselTolker = ForespoerselTolker(forespoerselRepository, mockMottakRepository)
+        forespoerselTolker =
+            ForespoerselTolker(
+                forespoerselRepository = forespoerselRepository,
+                mottakRepository = mockMottakRepository,
+                dialogportenService = mockk(),
+            )
     }
 
     @BeforeEach
@@ -61,7 +66,12 @@ class KafkaErrorHandlingTest {
     fun `ugyldig forespørsel eller manglende forespørselId i forespørselmelding skal kaste exception og stoppe videre lesing fra kafka`() {
         every { mockMottakRepository.opprett(any()) } returns 100
         val mockForespoerselRepository = mockk<ForespoerselRepository>()
-        val mockConsumer = ForespoerselTolker(mockForespoerselRepository, mockMottakRepository)
+        val mockConsumer =
+            ForespoerselTolker(
+                forespoerselRepository = mockForespoerselRepository,
+                mottakRepository = mockMottakRepository,
+                dialogportenService = mockk(),
+            )
         assertThrows<SerializationException> {
             mockConsumer.lesMelding(UGYLDIG_FORESPOERSEL_MOTTATT)
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
@@ -96,7 +96,7 @@ class MeldingTolkerTest {
 
     @Test
     fun kunLagreEventerSomMatcher() {
-        every { service.dialogportenService.oppdaterDialogMedInntektsmeldingforespoersel(any()) } just Runs
+        every { service.dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(any()) } just Runs
         // Test at kjente payloads ikke kræsjer:
         tolkere.forespoerselTolker.lesMelding(FORESPOERSEL_MOTTATT)
 
@@ -134,7 +134,7 @@ class MeldingTolkerTest {
 
     @Test
     fun `forespoerselTolker håndterer duplikater`() {
-        every { service.dialogportenService.oppdaterDialogMedInntektsmeldingforespoersel(any()) } just Runs
+        every { service.dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(any()) } just Runs
         assertDoesNotThrow {
             tolkere.forespoerselTolker.lesMelding(FORESPOERSEL_MOTTATT)
             tolkere.forespoerselTolker.lesMelding(FORESPOERSEL_MOTTATT)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/MeldingTolkerTest.kt
@@ -96,6 +96,7 @@ class MeldingTolkerTest {
 
     @Test
     fun kunLagreEventerSomMatcher() {
+        every { service.dialogportenService.oppdaterDialogMedInntektsmeldingforespoersel(any()) } just Runs
         // Test at kjente payloads ikke kræsjer:
         tolkere.forespoerselTolker.lesMelding(FORESPOERSEL_MOTTATT)
 
@@ -133,6 +134,7 @@ class MeldingTolkerTest {
 
     @Test
     fun `forespoerselTolker håndterer duplikater`() {
+        every { service.dialogportenService.oppdaterDialogMedInntektsmeldingforespoersel(any()) } just Runs
         assertDoesNotThrow {
             tolkere.forespoerselTolker.lesMelding(FORESPOERSEL_MOTTATT)
             tolkere.forespoerselTolker.lesMelding(FORESPOERSEL_MOTTATT)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRepositoryTest.kt
@@ -141,7 +141,7 @@ class SoeknadRepositoryTest {
             List(3) { UUID.randomUUID() }.map { id ->
                 soeknadMock().copy(
                     id = id,
-                    arbeidsgiver = SykepengesoknadDTO.ArbeidsgiverDTO("Test organisasjon", orgnr.verdi),
+                    arbeidsgiver = SykepengesoknadDTO.ArbeidsgiverDTO("Testorganisasjon", orgnr.verdi),
                 )
             }
         val soeknader =
@@ -168,7 +168,7 @@ class SoeknadRepositoryTest {
                     id = id,
                     arbeidsgiver =
                         SykepengesoknadDTO.ArbeidsgiverDTO(
-                            "Tilfeltdig Tigerorg",
+                            "Tilfeldig Tigerorg",
                             Orgnr.genererGyldig().verdi,
                         ),
                 )


### PR DESCRIPTION
**Bakgrunn**
Vi ønsker å varsle arbeidsgivere om at det er kommet en forespørsel om inntektsmelding. Denne varslingen skal skje gjennom Dialogporten, hvor forespørselen skal knyttes sammen med sykmeldingen den hører til.

**Løsning**
1. Bruk koblingen mellom vedtaksperiode og søknader som vi har lest fra status-i-speil-topicet til å finne sykmeldingen til den nyeste søknaden for vedtaksperioden i forespørselen. 
Altså: `forespørsel` -> `vedtaksperiode` -> `søknader (velger nyeste)` -> `sykmelding`.
3. Send melding til hag-dialog om at vi skal legge forespørselen til dialogen som hører til sykmeldingen vi fant i 1.