### PR TITLE
Mock Unleash sin oppførsel i forespørselintegrasjonstest

### DIFF
--- a/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ForespoerselIT.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ForespoerselIT.kt
@@ -7,6 +7,7 @@ import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.TestApplication
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import no.nav.helsearbeidsgiver.apiModule
@@ -15,14 +16,15 @@ import no.nav.helsearbeidsgiver.config.Repositories
 import no.nav.helsearbeidsgiver.config.Services
 import no.nav.helsearbeidsgiver.config.configureRepositories
 import no.nav.helsearbeidsgiver.config.configureServices
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
 import no.nav.helsearbeidsgiver.felles.auth.AuthClient
 import no.nav.helsearbeidsgiver.forespoersel.Forespoersel
 import no.nav.helsearbeidsgiver.forespoersel.Status
 import no.nav.helsearbeidsgiver.kafka.forespoersel.ForespoerselTolker
 import no.nav.helsearbeidsgiver.testcontainer.WithPostgresContainer
 import no.nav.helsearbeidsgiver.utils.TestData
+import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.jetbrains.exposed.sql.Database
 import org.junit.jupiter.api.AfterAll
@@ -36,6 +38,8 @@ class ForespoerselIT {
     private lateinit var services: Services
     private lateinit var forespoerselTolker: ForespoerselTolker
     private val authClient = mockk<AuthClient>(relaxed = true)
+
+    private val orgnr = Orgnr("810007982")
 
     private val port = 33445
     private val mockOAuth2Server =
@@ -54,7 +58,6 @@ class ForespoerselIT {
                 json()
             }
         }
-    private val dialogportenService: DialogportenService = mockk(relaxed = true)
 
     @BeforeAll
     fun setup() {
@@ -65,11 +68,16 @@ class ForespoerselIT {
                 System.getProperty("database.password"),
             ).init()
         repositories = configureRepositories(db)
-        services = configureServices(repositories, authClient, mockk(), db)
+
+        val unleashMock = mockk<UnleashFeatureToggles>()
+        every { unleashMock.skalOppdatereDialogVedMottattInntektsmeldingsforespoersel(orgnr) } returns true
+
+        services = configureServices(repositories, authClient, unleashMock, db)
+
         forespoerselTolker =
             ForespoerselTolker(
                 mottakRepository = repositories.mottakRepository,
-                dialogportenService = dialogportenService,
+                dialogportenService = services.dialogportenService,
                 forespoerselService = services.forespoerselService,
             )
     }
@@ -80,16 +88,15 @@ class ForespoerselIT {
             forespoerselTolker.lesMelding(
                 TestData.FORESPOERSEL_MOTTATT,
             )
-            val orgnr1 = "810007982"
             val response =
                 client.get("/v1/forespoersler") {
-                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(orgnr1))
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(orgnr.toString()))
                 }
             response.status.value shouldBe 200
             val forespoerselSvar = response.body<List<Forespoersel>>()
             forespoerselSvar.size shouldBe 1
             forespoerselSvar[0].status shouldBe Status.AKTIV
-            forespoerselSvar[0].orgnr shouldBe orgnr1
+            forespoerselSvar[0].orgnr shouldBe orgnr.toString()
         }
     }
 


### PR DESCRIPTION
**Bakgrunn**
Jeg fant noe rart i denne testen da jeg gikk gjennom testene våre for å feilsøke hvorfor testene ikke kjører grønt når vi prøver å prodsette. Nemlig at vi mocker `DialogportenService` istedenfor å bruke den `DialogportenService`-instansen som finnes inne i `services`.

**Løsning**
Bruk `services.dialogportenService` i forespørseltolkeren og mock heller Unleash.