### PR TITLE
Bytt til runBlocking i integrasjonstestene

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   build_and_deploy:
     name: Build, push and deploy
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   Test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ForespoerselIT.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ForespoerselIT.kt
@@ -37,8 +37,6 @@ class ForespoerselIT {
     private lateinit var forespoerselTolker: ForespoerselTolker
     private val authClient = mockk<AuthClient>(relaxed = true)
 
-    private val orgnr = "810007982"
-
     private val port = 33445
     private val mockOAuth2Server =
         MockOAuth2Server().apply {
@@ -81,11 +79,13 @@ class ForespoerselIT {
         forespoerselTolker.lesMelding(
             TestData.FORESPOERSEL_MOTTATT,
         )
+
+        val orgnr1 = "810007982"
+
         runBlocking {
             val response =
-
                 client.get("/v1/forespoersler") {
-                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(orgnr))
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(orgnr1))
                 }
             response.status.value shouldBe 200
 
@@ -93,7 +93,7 @@ class ForespoerselIT {
 
             forespoerselSvar.size shouldBe 1
             forespoerselSvar[0].status shouldBe Status.AKTIV
-            forespoerselSvar[0].orgnr shouldBe orgnr
+            forespoerselSvar[0].orgnr shouldBe orgnr1
         }
     }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/InnsendingIT.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/InnsendingIT.kt
@@ -88,18 +88,18 @@ class InnsendingIT {
         inntektsmeldingTolker.lesMelding(
             buildJournalfoertInntektsmelding(orgNr = Orgnr(orgnr1)),
         )
-        val response =
-            runBlocking {
+        runBlocking {
+            val response =
+
                 client.get("/v1/inntektsmeldinger") {
                     bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(orgnr1))
                 }
-            }
-
-        response.status shouldBe HttpStatusCode.OK
-        val forespoerselSvar = runBlocking { response.body<List<InntektsmeldingResponse>>() }
-        forespoerselSvar.size shouldBe 1
-        forespoerselSvar[0].status shouldBe InnsendingStatus.GODKJENT
-        forespoerselSvar[0].arbeidsgiver.orgnr shouldBe orgnr1
+            response.status shouldBe HttpStatusCode.OK
+            val forespoerselSvar = response.body<List<InntektsmeldingResponse>>()
+            forespoerselSvar.size shouldBe 1
+            forespoerselSvar[0].status shouldBe InnsendingStatus.GODKJENT
+            forespoerselSvar[0].arbeidsgiver.orgnr shouldBe orgnr1
+        }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/InntektsmeldingApiTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/InntektsmeldingApiTest.kt
@@ -4,7 +4,7 @@ import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.runBlocking
 import no.nav.helsearbeidsgiver.innsending.InnsendingStatus
 import no.nav.helsearbeidsgiver.inntektsmelding.InntektsmeldingResponse
 import no.nav.helsearbeidsgiver.testcontainer.LpsApiIntegrasjontest
@@ -25,7 +25,7 @@ class InntektsmeldingApiTest : LpsApiIntegrasjontest() {
         val inntektsmelding2 = buildInntektsmelding(inntektsmeldingId = id2, orgNr = Orgnr(DEFAULT_ORG))
         repositories.inntektsmeldingRepository.opprettInntektsmelding(inntektsmelding1, InnsendingStatus.GODKJENT)
         repositories.inntektsmeldingRepository.opprettInntektsmelding(inntektsmelding2, InnsendingStatus.MOTTATT)
-        runTest {
+        runBlocking {
             val response =
                 fetchWithRetry(
                     url = "http://localhost:8080/v1/inntektsmelding/status/GODKJENT",
@@ -59,7 +59,8 @@ class InntektsmeldingApiTest : LpsApiIntegrasjontest() {
             )
         repositories.inntektsmeldingRepository.opprettInntektsmelding(inntektsmelding1)
         repositories.inntektsmeldingRepository.opprettInntektsmelding(inntektsmelding2)
-        runTest {
+
+        runBlocking {
             val response =
                 fetchWithRetry(
                     url = "http://localhost:8080/v1/inntektsmelding/navReferanseId/$im1NavReferanseId",
@@ -67,6 +68,7 @@ class InntektsmeldingApiTest : LpsApiIntegrasjontest() {
                 )
 
             val inntektsmeldingResponse = response.body<List<InntektsmeldingResponse>>()
+
             inntektsmeldingResponse.size shouldBe 1
             inntektsmeldingResponse[0].navReferanseId shouldBe im1NavReferanseId
             inntektsmeldingResponse[0].id shouldBe id1
@@ -82,7 +84,7 @@ class InntektsmeldingApiTest : LpsApiIntegrasjontest() {
         val missingId = UUID.randomUUID()
         repositories.inntektsmeldingRepository.opprettInntektsmelding(inntektsmelding1)
         repositories.inntektsmeldingRepository.opprettInntektsmelding(inntektsmelding2)
-        runTest {
+        runBlocking {
             val ok =
                 fetchWithRetry(
                     url = "http://localhost:8080/v1/inntektsmelding/$id1",


### PR DESCRIPTION
**Bakgrunn**
Testene kjører ikke grønt på release, og vi mistenker at grunnen kan være `runTest`, som ikke respekterer delays.

**Løsning**
 Bytt fra `runTest` til `runBlocking` i integrasjonstestene.