### PR TITLE
soknad: støtt orgnr i request (systembruker på hovedenhet)

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselRouting.kt
@@ -82,6 +82,9 @@ private fun Route.forespoersel(forespoerselService: ForespoerselService) {
             )
             call.respond(forespoersel)
         } catch (_: IllegalArgumentException) {
+            // TODO: Kan hende at vi må catche denne kun rundt navReferanse-parsing - gjelder andre entiteter /ruter også.
+            // Eller vi kan pakke inn feil i egne service-exceptions el.l.
+            // I søknad-rute boblet en require fra entitet-laget opp hit, og ga en uforståelig badrequest-feilmelding (og ingen logger)
             call.respond(HttpStatusCode.BadRequest, "Ugyldig identifikator")
         } catch (e: Exception) {
             sikkerLogger().error("Feil ved henting av forespørsler", e)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
@@ -1,9 +1,12 @@
 package no.nav.helsearbeidsgiver.soeknad
 
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.helsearbeidsgiver.Env
 import no.nav.helsearbeidsgiver.auth.getConsumerOrgnr
@@ -11,16 +14,62 @@ import no.nav.helsearbeidsgiver.auth.getSystembrukerOrgnr
 import no.nav.helsearbeidsgiver.auth.harTilgangTilRessurs
 import no.nav.helsearbeidsgiver.auth.tokenValidationContext
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr.Companion.erGyldig
 import java.util.UUID
 
 private val SOKNAD_RESSURS = Env.getProperty("ALTINN_SOKNAD_RESSURS")
 
 fun Route.soeknadV1(soeknadService: SoeknadService) {
     route("/v1") {
+        soeknad(soeknadService)
+        filtrerSoeknader(soeknadService)
         soeknader(soeknadService)
     }
 }
 
+private fun Route.soeknad(soeknadService: SoeknadService) {
+    // Hent én sykepengesøknad basert på søknadId
+    get("/sykepengesoeknad/{soeknadId}") {
+        try {
+            val soeknadId = call.parameters["soeknadId"]?.let { UUID.fromString(it) }
+            requireNotNull(soeknadId) { "soeknadId: $soeknadId ikke gyldig UUID" }
+
+            val soeknad = soeknadService.hentSoeknad(soeknadId)
+
+            if (soeknad == null) {
+                call.respond(HttpStatusCode.NotFound, "Fant ingen søknad for id $soeknadId")
+                return@get
+            }
+            val systembrukerOrgnr = tokenValidationContext().getSystembrukerOrgnr()
+            val lpsOrgnr = tokenValidationContext().getConsumerOrgnr()
+
+            if (!tokenValidationContext().harTilgangTilRessurs(
+                    ressurs = SOKNAD_RESSURS,
+                    orgnumre = setOf(soeknad.arbeidsgiver.orgnr, systembrukerOrgnr),
+                )
+            ) {
+                call.respond(HttpStatusCode.Unauthorized, "Ikke tilgang til ressurs")
+                return@get
+            }
+            sikkerLogger().info("LPS: [$lpsOrgnr] henter søknad med id: [$soeknadId] på vegne av orgnr: $systembrukerOrgnr")
+
+            call.respond(soeknad)
+        } catch (e: IllegalArgumentException) {
+            sikkerLogger().error(e.message, e)
+            call.respond(HttpStatusCode.NotFound, "Ikke gyldig søknadId")
+        } catch (e: Exception) {
+            sikkerLogger().error("Feil ved henting av søknader", e)
+            call.respond(HttpStatusCode.InternalServerError, "Feil ved henting av søknad")
+        }
+    }
+}
+
+@Deprecated(
+    message =
+        "Fungerer kun dersom systembruker er satt opp på sluttbruker-organisasjonens underenhet. " +
+            "Vi anbefaler å bruke POST /sykepengesoeknader istedenfor.",
+    level = DeprecationLevel.WARNING,
+)
 private fun Route.soeknader(soeknadService: SoeknadService) {
     // Hent sykepengesøknader sendt til tilhørende systembrukers orgnr.
     get("/sykepengesoeknader") {
@@ -32,40 +81,49 @@ private fun Route.soeknader(soeknadService: SoeknadService) {
                 call.respond(HttpStatusCode.Unauthorized, "Ikke tilgang til ressurs")
                 return@get
             }
-            val soeknader: List<Sykepengesoeknad> = soeknadService.hentSoeknader(sluttbrukerOrgnr)
+            val soeknader: List<Sykepengesoeknad> =
+                soeknadService.hentSoeknader(
+                    sluttbrukerOrgnr,
+                )
             call.respond(soeknader)
         } catch (e: Exception) {
             sikkerLogger().error("Feil ved henting av søknader", e)
             call.respond(HttpStatusCode.InternalServerError, "Feil ved henting av søknader")
         }
     }
+}
 
-    // Hent én sykepengesøknad basert på søknadId
-    get("/sykepengesoeknad/{soeknadId}") {
+private fun Route.filtrerSoeknader(soeknadService: SoeknadService) {
+    // Filtrer søknader på fnr, underenhet og / eller dato (mottattAvNav)
+    post("/sykepengesoeknader") {
+        // Hent alle søknader for et orgnr, filtrert med parametere
         try {
-            val soeknadId = call.parameters["soeknadId"]?.let { UUID.fromString(it) }
-            requireNotNull(soeknadId) { "soeknadId: $soeknadId ikke gyldig UUID" }
+            val request = call.receive<SykepengesoeknadFilter>()
+            val systembrukerOrgnr = tokenValidationContext().getSystembrukerOrgnr().also { require(erGyldig(it)) }
+            val orgnr = request.orgnr ?: systembrukerOrgnr
 
-            val sluttbrukerOrgnr = tokenValidationContext().getSystembrukerOrgnr()
-            val lpsOrgnr = tokenValidationContext().getConsumerOrgnr()
-            if (!tokenValidationContext().harTilgangTilRessurs(SOKNAD_RESSURS)) {
+            if (!tokenValidationContext().harTilgangTilRessurs(
+                    ressurs = SOKNAD_RESSURS,
+                    orgnumre = setOf(orgnr, systembrukerOrgnr),
+                )
+            ) {
                 call.respond(HttpStatusCode.Unauthorized, "Ikke tilgang til ressurs")
-                return@get
+                return@post
             }
-            sikkerLogger().info("LPS: [$lpsOrgnr] henter søknad med id: [$soeknadId] på vegne av orgnr: $sluttbrukerOrgnr")
 
-            val soeknad = soeknadService.hentSoeknad(soeknadId, sluttbrukerOrgnr)
-            if (soeknad == null) {
-                call.respond(HttpStatusCode.NotFound, "Fant ingen søknad for id $soeknadId")
-            } else {
-                call.respond(soeknad)
-            }
-        } catch (e: IllegalArgumentException) {
-            sikkerLogger().error(e.message, e)
-            call.respond(HttpStatusCode.NotFound, "Ikke gyldig søknadId")
+            val lpsOrgnr = tokenValidationContext().getConsumerOrgnr()
+
+            sikkerLogger().info(
+                "LPS: [$lpsOrgnr] henter sykepengesøknader for orgnr [$orgnr] for bedrift med systembrukerOrgnr: [$systembrukerOrgnr]",
+            )
+            call.respond(soeknadService.hentSoeknader(orgnr, request))
+        } catch (_: IllegalArgumentException) {
+            call.respond(HttpStatusCode.BadRequest, "Ugyldig identifikator")
+        } catch (_: BadRequestException) {
+            call.respond(HttpStatusCode.BadRequest, "Ugyldig filterparameter")
         } catch (e: Exception) {
-            sikkerLogger().error("Feil ved henting av søknader", e)
-            call.respond(HttpStatusCode.InternalServerError, "Feil ved henting av søknad")
+            sikkerLogger().error("Feil ved henting av sykepengesøknader", e)
+            call.respond(HttpStatusCode.InternalServerError, "Feil ved henting av sykepengesøknader")
         }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
@@ -117,8 +117,6 @@ private fun Route.filtrerSoeknader(soeknadService: SoeknadService) {
                 "LPS: [$lpsOrgnr] henter sykepengesøknader for orgnr [$orgnr] for bedrift med systembrukerOrgnr: [$systembrukerOrgnr]",
             )
             call.respond(soeknadService.hentSoeknader(orgnr, request))
-        } catch (_: IllegalArgumentException) {
-            call.respond(HttpStatusCode.BadRequest, "Ugyldig identifikator")
         } catch (_: BadRequestException) {
             call.respond(HttpStatusCode.BadRequest, "Ugyldig filterparameter")
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadService.kt
@@ -16,17 +16,13 @@ class SoeknadService(
 ) {
     private val logger = logger()
 
-    fun hentSoeknader(orgnr: String): List<Sykepengesoeknad> =
-        soeknadRepository.hentSoeknader(orgnr).map { it.whitelistetForArbeidsgiver().konverter() }
-
-    fun hentSoeknad(
-        soeknadId: UUID,
+    fun hentSoeknader(
         orgnr: String,
-    ): Sykepengesoeknad? =
-        soeknadRepository.hentSoeknad(soeknadId)?.whitelistetForArbeidsgiver()?.konverter().takeIf {
-            it?.arbeidsgiver?.orgnr ==
-                orgnr
-        }
+        filter: SykepengesoeknadFilter? = null,
+    ): List<Sykepengesoeknad> = soeknadRepository.hentSoeknader(orgnr, filter).map { it.whitelistetForArbeidsgiver().konverter() }
+
+    fun hentSoeknad(soeknadId: UUID): Sykepengesoeknad? =
+        soeknadRepository.hentSoeknad(soeknadId)?.whitelistetForArbeidsgiver()?.konverter()
 
     fun behandleSoeknad(soeknad: SykepengesoknadDTO) {
         if (!soeknad.skalLagres()) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SykepengesoeknadFilter.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SykepengesoeknadFilter.kt
@@ -1,0 +1,24 @@
+@file:UseSerializers(LocalDateSerializer::class)
+
+package no.nav.helsearbeidsgiver.soeknad
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr.Companion.erGyldig
+import java.time.LocalDate
+
+@Serializable
+data class SykepengesoeknadFilter( // TODO: Kanskje denne kan de-dupliseres / generaliseres til å gjelde flere typer?
+    val orgnr: String? = null,
+    val fnr: String? = null,
+    val fom: LocalDate? = null,
+    val tom: LocalDate? = null,
+) {
+    init {
+        orgnr?.let { require(erGyldig(orgnr)) }
+        fom?.year?.let { require(it >= 0) }
+        tom?.year?.let { require(it <= 9999) } // Om man tillater alt opp til LocalDate.MAX
+        // vil det bli long-overflow ved konvertering til exposed sql-javadate i db-spørring
+    }
+}

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/SoeknadUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/SoeknadUtils.kt
@@ -39,8 +39,9 @@ fun SykepengesoknadDTO.SoknadsperiodeDTO.konverter(): Sykepengesoeknad.Soeknadsp
 }
 
 private fun SykepengesoknadDTO.utledSendtTid(): LocalDateTime {
-    // sendtArbeidsgiver og sendtNav blir populert av samme verdi så en av dem vil alltid være satt.
-    val sendt = sendtArbeidsgiver ?: sendtNav
+    // sendtArbeidsgiver og sendtNav blir populert av samme verdi så en av dem skal alltid være satt.
+    // Lagt til fallback til "opprettet":  noen rader i dev manglet begge sendt-feltene..!
+    val sendt = sendtArbeidsgiver ?: sendtNav ?: opprettet
     requireNotNull(sendt)
     return sendt
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/authorization/ApiTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/authorization/ApiTest.kt
@@ -4,15 +4,24 @@ import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.TestApplication
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import no.nav.helsearbeidsgiver.apiModule
 import no.nav.helsearbeidsgiver.config.Repositories
 import no.nav.helsearbeidsgiver.config.Services
 import no.nav.helsearbeidsgiver.config.configureServices
+import no.nav.helsearbeidsgiver.config.getPdpService
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 
 abstract class ApiTest {
+    val orgnrUtenPdpTilgang = Orgnr.genererGyldig().toString()
+    val hovedenhetOrgnrMedPdpTilgang = Orgnr.genererGyldig().toString()
+    val underenhetOrgnrMedPdpTilgang = Orgnr.genererGyldig().toString()
+
     val repositories: Repositories = mockk<Repositories>(relaxed = true)
     val services: Services =
         configureServices(
@@ -44,5 +53,44 @@ abstract class ApiTest {
     fun shutdownStuff() {
         testApplication.stop()
         mockOAuth2Server.shutdown()
+    }
+
+    fun mockPdpTilganger() {
+        mockkStatic("no.nav.helsearbeidsgiver.config.ApplicationConfigKt")
+        every {
+            getPdpService().harTilgang(
+                systembruker = any(),
+                orgnr = orgnrUtenPdpTilgang,
+                ressurs = any(),
+            )
+        } returns false
+
+        every {
+            getPdpService().harTilgang(
+                systembruker = any(),
+                orgnr = match { it == hovedenhetOrgnrMedPdpTilgang || it == underenhetOrgnrMedPdpTilgang },
+                ressurs = any(),
+            )
+        } returns true
+
+        every {
+            getPdpService().harTilgang(
+                systembruker = any(),
+                orgnumre = match { it.contains(orgnrUtenPdpTilgang) },
+                ressurs = any(),
+            )
+        } returns false
+
+        every {
+            getPdpService().harTilgang(
+                systembruker = any(),
+                orgnumre =
+                    match {
+                        (it.contains(hovedenhetOrgnrMedPdpTilgang) || it.contains(underenhetOrgnrMedPdpTilgang)) &&
+                            !it.contains(orgnrUtenPdpTilgang)
+                    },
+                ressurs = any(),
+            )
+        } returns true
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselAuthTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselAuthTest.kt
@@ -11,27 +11,19 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.mockk.clearMocks
 import io.mockk.every
-import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import kotlinx.coroutines.runBlocking
 import no.nav.helsearbeidsgiver.authorization.ApiTest
-import no.nav.helsearbeidsgiver.config.getPdpService
 import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.mockForespoersel
-import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.ugyldigTokenManglerSystembruker
-import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class ForespoerselAuthTest : ApiTest() {
-    private val orgnrUtenPdpTilgang = Orgnr.genererGyldig().toString()
-    private val hovedenhetOrgnrMedPdpTilgang = Orgnr.genererGyldig().toString()
-    private val underenhetOrgnrMedPdpTilgang = Orgnr.genererGyldig().toString()
-
     @BeforeAll
     fun setup() {
         clearMocks(repositories.forespoerselRepository)
@@ -302,44 +294,5 @@ class ForespoerselAuthTest : ApiTest() {
                 }
             }
         response4.status shouldBe HttpStatusCode.Unauthorized
-    }
-
-    private fun mockPdpTilganger() {
-        mockkStatic("no.nav.helsearbeidsgiver.config.ApplicationConfigKt")
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnr = orgnrUtenPdpTilgang,
-                ressurs = any(),
-            )
-        } returns false
-
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnr = match { it == hovedenhetOrgnrMedPdpTilgang || it == underenhetOrgnrMedPdpTilgang },
-                ressurs = any(),
-            )
-        } returns true
-
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnumre = match { it.contains(orgnrUtenPdpTilgang) },
-                ressurs = any(),
-            )
-        } returns false
-
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnumre =
-                    match {
-                        (it.contains(hovedenhetOrgnrMedPdpTilgang) || it.contains(underenhetOrgnrMedPdpTilgang)) &&
-                            !it.contains(orgnrUtenPdpTilgang)
-                    },
-                ressurs = any(),
-            )
-        } returns true
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadAuthTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadAuthTest.kt
@@ -1,0 +1,364 @@
+package no.nav.helsearbeidsgiver.soeknad
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import no.nav.helsearbeidsgiver.authorization.ApiTest
+import no.nav.helsearbeidsgiver.config.getPdpService
+import no.nav.helsearbeidsgiver.utils.TestData.medId
+import no.nav.helsearbeidsgiver.utils.TestData.medOrgnr
+import no.nav.helsearbeidsgiver.utils.TestData.soeknadMock
+import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
+import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.ugyldigTokenManglerSystembruker
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+// TODO: Duplisert - kan slå sammen alle *AuthTester?
+class SoeknadAuthTest : ApiTest() {
+    private val orgnrUtenPdpTilgang = Orgnr.genererGyldig().toString()
+    private val hovedenhetOrgnrMedPdpTilgang = Orgnr.genererGyldig().toString()
+    private val underenhetOrgnrMedPdpTilgang = Orgnr.genererGyldig().toString()
+
+    @BeforeEach
+    fun setup() {
+        clearMocks(repositories.soeknadRepository)
+        mockPdpTilganger()
+    }
+
+    @AfterAll
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `gir 200 OK ved henting av soeknader fra deprecated endepunkt`() {
+        every { repositories.soeknadRepository.hentSoeknader(underenhetOrgnrMedPdpTilgang, null) } returns
+            listOf(
+                soeknadMock()
+                    .medOrgnr(underenhetOrgnrMedPdpTilgang),
+            )
+        runBlocking {
+            val response =
+                client.get("/v1/sykepengesoeknader") {
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(underenhetOrgnrMedPdpTilgang))
+                }
+            response.status shouldBe HttpStatusCode.OK
+            val soeknadSvar = response.body<List<Sykepengesoeknad>>()
+            soeknadSvar.size shouldBe 1
+            soeknadSvar[0].arbeidsgiver.orgnr shouldBe underenhetOrgnrMedPdpTilgang
+        }
+    }
+
+    @Test
+    fun `gir 200 OK ved henting av en spesifikk soeknad`() {
+        val soeknadId = UUID.randomUUID()
+        every { repositories.soeknadRepository.hentSoeknad(soeknadId) } returns
+            soeknadMock()
+                .medId(soeknadId)
+                .medOrgnr(underenhetOrgnrMedPdpTilgang)
+
+        runBlocking {
+            val response =
+                client.get("/v1/sykepengesoeknad/$soeknadId") {
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(hovedenhetOrgnrMedPdpTilgang))
+                }
+            response.status shouldBe HttpStatusCode.OK
+            val soeknadSvar = response.body<Sykepengesoeknad>()
+            soeknadSvar.arbeidsgiver.orgnr shouldBe underenhetOrgnrMedPdpTilgang
+        }
+    }
+
+    @Test
+    fun `gir 200 OK ved henting av flere soeknader på underenhetorgnr hentet fra request`() {
+        val antallForventedesoeknader = 3
+        every {
+            repositories.soeknadRepository.hentSoeknader(
+                orgnr = underenhetOrgnrMedPdpTilgang,
+                filter = SykepengesoeknadFilter(orgnr = underenhetOrgnrMedPdpTilgang),
+            )
+        } returns
+            List(
+                antallForventedesoeknader,
+            ) {
+                soeknadMock()
+                    .medId(UUID.randomUUID())
+                    .medOrgnr(underenhetOrgnrMedPdpTilgang)
+            }
+
+        runBlocking {
+            val response =
+                client.post("/v1/sykepengesoeknader") {
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        SykepengesoeknadFilter(
+                            orgnr = underenhetOrgnrMedPdpTilgang,
+                        ).toJson(serializer = SykepengesoeknadFilter.serializer()),
+                    )
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(hovedenhetOrgnrMedPdpTilgang))
+                }
+            response.status shouldBe HttpStatusCode.OK
+            val soeknadSvar = response.body<List<Sykepengesoeknad>>()
+            soeknadSvar.size shouldBe antallForventedesoeknader
+            soeknadSvar.forEach {
+                it.arbeidsgiver.orgnr shouldBe underenhetOrgnrMedPdpTilgang
+            }
+        }
+    }
+
+    @Test
+    fun `gir 200 OK ved henting av flere soeknader på underenhetorgnr hentet fra systembruker`() {
+        val antallForventedesoeknader = 3
+        val requestUtenOrgnr = SykepengesoeknadFilter()
+        every {
+            repositories.soeknadRepository.hentSoeknader(underenhetOrgnrMedPdpTilgang, requestUtenOrgnr)
+        } returns
+            List(
+                antallForventedesoeknader,
+            ) {
+                soeknadMock()
+                    .medId(UUID.randomUUID())
+                    .medOrgnr(underenhetOrgnrMedPdpTilgang)
+            }
+
+        runBlocking {
+            val response =
+                client.post("/v1/sykepengesoeknader") {
+                    contentType(ContentType.Application.Json)
+                    setBody(requestUtenOrgnr.toJson(serializer = SykepengesoeknadFilter.serializer()))
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(underenhetOrgnrMedPdpTilgang))
+                }
+            response.status shouldBe HttpStatusCode.OK
+            val soeknadSvar = response.body<List<Sykepengesoeknad>>()
+            soeknadSvar.size shouldBe antallForventedesoeknader
+            soeknadSvar.forEach {
+                it.arbeidsgiver.orgnr shouldBe underenhetOrgnrMedPdpTilgang
+            }
+        }
+    }
+
+    @Test
+    fun `gir 401 Unauthorized når token mangler ved henting av soeknader`() {
+        val response1 = runBlocking { client.get("/v1/sykepengesoeknader") }
+        response1.status shouldBe HttpStatusCode.Unauthorized
+
+        val response2 = runBlocking { client.get("/v1/sykepengesoeknad/${UUID.randomUUID()}") }
+        response2.status shouldBe HttpStatusCode.Unauthorized
+
+        val requestBody = SykepengesoeknadFilter(orgnr = underenhetOrgnrMedPdpTilgang)
+        val response3 =
+            runBlocking {
+                client.post("/v1/sykepengesoeknader") {
+                    contentType(ContentType.Application.Json)
+                    setBody(requestBody.toJson(serializer = SykepengesoeknadFilter.serializer()))
+                }
+            }
+        response3.status shouldBe HttpStatusCode.Unauthorized
+    }
+
+    @Test
+    fun `gir 401 Unauthorized når systembruker mangler i token ved henting av soeknader`() {
+        val response1 =
+            runBlocking {
+                client.get("/v1/sykepengesoeknader") {
+                    bearerAuth(mockOAuth2Server.ugyldigTokenManglerSystembruker())
+                }
+            }
+        response1.status shouldBe HttpStatusCode.Unauthorized
+
+        val response2 =
+            runBlocking {
+                client.get("/v1/sykepengesoeknad/${UUID.randomUUID()}") {
+                    bearerAuth(mockOAuth2Server.ugyldigTokenManglerSystembruker())
+                }
+            }
+        response2.status shouldBe HttpStatusCode.Unauthorized
+
+        val response3 =
+            runBlocking {
+                client.post("/v1/sykepengesoeknader") {
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        SykepengesoeknadFilter(
+                            orgnr = underenhetOrgnrMedPdpTilgang,
+                        ).toJson(serializer = SykepengesoeknadFilter.serializer()),
+                    )
+                    bearerAuth(mockOAuth2Server.ugyldigTokenManglerSystembruker())
+                }
+            }
+        response3.status shouldBe HttpStatusCode.Unauthorized
+    }
+
+    @Test
+    fun `gir 401 Unauthorized når pdp nekter tilgang for systembrukeren fra deprecated endepunkt`() {
+        val soeknadId = UUID.randomUUID()
+        every { repositories.soeknadRepository.hentSoeknader(underenhetOrgnrMedPdpTilgang) } returns
+            listOf(
+                soeknadMock()
+                    .medId(soeknadId)
+                    .medOrgnr(underenhetOrgnrMedPdpTilgang),
+            )
+
+        val response =
+            runBlocking {
+                client.get("/v1/sykepengesoeknader") {
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(orgnrUtenPdpTilgang))
+                }
+            }
+        response.status shouldBe HttpStatusCode.Unauthorized
+    }
+
+    @Test
+    fun `gir 401 Unauthorized når pdp nekter tilgang for systembrukeren for henting av en spesifikk soeknad`() {
+        val soeknadIdIkkeTilgang = UUID.randomUUID()
+        val soeknadIkkeTilgang =
+            soeknadMock()
+                .medId(soeknadIdIkkeTilgang)
+                .medOrgnr(orgnrUtenPdpTilgang)
+
+        every { repositories.soeknadRepository.hentSoeknad(soeknadIdIkkeTilgang) } returns soeknadIkkeTilgang
+
+        val soeknadIdTilgang = UUID.randomUUID()
+        val soeknadTilgang =
+            soeknadMock()
+                .medId(soeknadIdTilgang)
+                .medOrgnr(underenhetOrgnrMedPdpTilgang)
+
+        every { repositories.soeknadRepository.hentSoeknad(soeknadIdTilgang) } returns soeknadTilgang
+        // Systembruker _har_ tilgang til hovedenhetorgnr (fra token), men har _ikke_ tilgang til underenhetorgnr (fra soeknad).
+        // Det vil si at man forsøker å hente en soeknad som systembrukeren ikke skal ha tilgang til.
+        val response1 =
+            runBlocking {
+                client.get("/v1/sykepengesoeknad/$soeknadIdIkkeTilgang") {
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(hovedenhetOrgnrMedPdpTilgang))
+                }
+            }
+        response1.status shouldBe HttpStatusCode.Unauthorized
+
+        // Systembruker har _ikke_ tilgang til orgnr i token, men _har_ tilgang til underenhetorgnr (fra soeknad).
+        val response2 =
+            runBlocking {
+                client.get("/v1/sykepengesoeknad/$soeknadIdTilgang") {
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(orgnrUtenPdpTilgang))
+                }
+            }
+        response2.status shouldBe HttpStatusCode.Unauthorized
+
+        // Systembruker har hverken tilgang til orgnr i token eller orgnr fra soeknad.
+        val response3 =
+            runBlocking {
+                client.get("/v1/sykepengesoeknad/$soeknadIdIkkeTilgang") {
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(orgnrUtenPdpTilgang))
+                }
+            }
+        response3.status shouldBe HttpStatusCode.Unauthorized
+    }
+
+    @Test
+    fun `gir 401 Unauthorized når pdp nekter tilgang for systembrukeren for henting av flere soeknader`() {
+        // Systembruker _har_ tilgang til hovedenhetorgnr (fra token), men har _ikke_ tilgang til underenhetorgnr (fra requesten).
+        // Det vil si at man forsøker å hente soeknader for en organisasjon som systembrukeren ikke skal ha tilgang til.
+        val response1 =
+            runBlocking {
+                client.post("/v1/sykepengesoeknader") {
+                    contentType(ContentType.Application.Json)
+                    setBody(SykepengesoeknadFilter(orgnr = orgnrUtenPdpTilgang).toJson(serializer = SykepengesoeknadFilter.serializer()))
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(hovedenhetOrgnrMedPdpTilgang))
+                }
+            }
+        response1.status shouldBe HttpStatusCode.Unauthorized
+
+        // Systembruker har _ikke_ tilgang til orgnr i token, men _har_ tilgang til underenhetsorgnr i requesten.
+        // Det vil si at man forsøker å hente soeknader for et orgnummer (fra requesten), men blir nektet tilgang fra pdp pga. orgnummeret i tokenet.
+        val response2 =
+            runBlocking {
+                client.post("/v1/sykepengesoeknader") {
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        SykepengesoeknadFilter(
+                            orgnr = underenhetOrgnrMedPdpTilgang,
+                        ).toJson(serializer = SykepengesoeknadFilter.serializer()),
+                    )
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(orgnrUtenPdpTilgang))
+                }
+            }
+        response2.status shouldBe HttpStatusCode.Unauthorized
+
+        // Systembruker har _ikke_ tilgang til orgnr i token, og har heller ikke angitt orgnr i requesten .
+        // Det vil si at man forsøker å hente soeknader for et orgnummer (fra tokenet) som pdp nekter systembrukeren tilgang til.
+        val response3 =
+            runBlocking {
+                client.post("/v1/sykepengesoeknader") {
+                    contentType(ContentType.Application.Json)
+                    setBody(SykepengesoeknadFilter(orgnr = null).toJson(serializer = SykepengesoeknadFilter.serializer()))
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(orgnrUtenPdpTilgang))
+                }
+            }
+        response3.status shouldBe HttpStatusCode.Unauthorized
+
+        // Systembruker har hverken tilgang til orgnr i token eller orgnr fra requesten.
+        val response4 =
+            runBlocking {
+                client.post("/v1/sykepengesoeknader") {
+                    contentType(ContentType.Application.Json)
+                    setBody(SykepengesoeknadFilter(orgnr = orgnrUtenPdpTilgang).toJson(serializer = SykepengesoeknadFilter.serializer()))
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(orgnrUtenPdpTilgang))
+                }
+            }
+        response4.status shouldBe HttpStatusCode.Unauthorized
+    }
+
+    private fun mockPdpTilganger() { // TODO: duplisert, slå sammen
+        mockkStatic("no.nav.helsearbeidsgiver.config.ApplicationConfigKt")
+        every {
+            getPdpService().harTilgang(
+                systembruker = any(),
+                orgnr = orgnrUtenPdpTilgang,
+                ressurs = any(),
+            )
+        } returns false
+
+        every {
+            getPdpService().harTilgang(
+                systembruker = any(),
+                orgnr = match { it == hovedenhetOrgnrMedPdpTilgang || it == underenhetOrgnrMedPdpTilgang },
+                ressurs = any(),
+            )
+        } returns true
+
+        every {
+            getPdpService().harTilgang(
+                systembruker = any(),
+                orgnumre = match { it.contains(orgnrUtenPdpTilgang) },
+                ressurs = any(),
+            )
+        } returns false
+
+        every {
+            getPdpService().harTilgang(
+                systembruker = any(),
+                orgnumre =
+                    match {
+                        (it.contains(hovedenhetOrgnrMedPdpTilgang) || it.contains(underenhetOrgnrMedPdpTilgang)) &&
+                            !it.contains(orgnrUtenPdpTilgang)
+                    },
+                ressurs = any(),
+            )
+        } returns true
+    }
+}

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadAuthTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadAuthTest.kt
@@ -11,19 +11,15 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.mockk.clearMocks
 import io.mockk.every
-import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import kotlinx.coroutines.runBlocking
 import no.nav.helsearbeidsgiver.authorization.ApiTest
-import no.nav.helsearbeidsgiver.config.getPdpService
 import no.nav.helsearbeidsgiver.utils.TestData.medId
 import no.nav.helsearbeidsgiver.utils.TestData.medOrgnr
 import no.nav.helsearbeidsgiver.utils.TestData.soeknadMock
 import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.ugyldigTokenManglerSystembruker
-import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -31,10 +27,6 @@ import java.util.UUID
 
 // TODO: Duplisert - kan slå sammen alle *AuthTester?
 class SoeknadAuthTest : ApiTest() {
-    private val orgnrUtenPdpTilgang = Orgnr.genererGyldig().toString()
-    private val hovedenhetOrgnrMedPdpTilgang = Orgnr.genererGyldig().toString()
-    private val underenhetOrgnrMedPdpTilgang = Orgnr.genererGyldig().toString()
-
     @BeforeEach
     fun setup() {
         clearMocks(repositories.soeknadRepository)
@@ -321,44 +313,5 @@ class SoeknadAuthTest : ApiTest() {
                 }
             }
         response4.status shouldBe HttpStatusCode.Unauthorized
-    }
-
-    private fun mockPdpTilganger() { // TODO: duplisert, slå sammen
-        mockkStatic("no.nav.helsearbeidsgiver.config.ApplicationConfigKt")
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnr = orgnrUtenPdpTilgang,
-                ressurs = any(),
-            )
-        } returns false
-
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnr = match { it == hovedenhetOrgnrMedPdpTilgang || it == underenhetOrgnrMedPdpTilgang },
-                ressurs = any(),
-            )
-        } returns true
-
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnumre = match { it.contains(orgnrUtenPdpTilgang) },
-                ressurs = any(),
-            )
-        } returns false
-
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnumre =
-                    match {
-                        (it.contains(hovedenhetOrgnrMedPdpTilgang) || it.contains(underenhetOrgnrMedPdpTilgang)) &&
-                            !it.contains(orgnrUtenPdpTilgang)
-                    },
-                ressurs = any(),
-            )
-        } returns true
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRepositoryTest.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.kafka.soeknad.SykepengesoknadDTO
 import no.nav.helsearbeidsgiver.sis.StatusISpeilRepository
 import no.nav.helsearbeidsgiver.soeknad.SoeknadEntitet.soeknadId
 import no.nav.helsearbeidsgiver.testcontainer.WithPostgresContainer
+import no.nav.helsearbeidsgiver.utils.TestData.medId
 import no.nav.helsearbeidsgiver.utils.TestData.soeknadMock
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
@@ -63,8 +64,8 @@ class SoeknadRepositoryTest {
     @Test
     fun `oppdaterSoeknaderMedVedtaksperiodeId skal lagre vedtaksperiodeId på flere søknader`() {
         val soeknad = soeknadMock()
-        val soeknad2 = soeknadMock().copy(id = UUID.randomUUID())
-        val soeknad3 = soeknadMock().copy(id = UUID.randomUUID())
+        val soeknad2 = soeknadMock().medId(id = UUID.randomUUID())
+        val soeknad3 = soeknadMock().medId(id = UUID.randomUUID())
         val vedtaksperiodeId = UUID.randomUUID()
 
         soeknadRepository.lagreSoeknad(soeknad.tilLagreSoeknad())
@@ -88,8 +89,8 @@ class SoeknadRepositoryTest {
     @Test
     fun `oppdaterSoeknaderMedVedtaksperiodeId skal bare oppdatere søknader som mangler vedtaksperiodeId`() {
         val soeknad = soeknadMock()
-        val soeknad2 = soeknadMock().copy(id = UUID.randomUUID())
-        val soeknad3 = soeknadMock().copy(id = UUID.randomUUID())
+        val soeknad2 = soeknadMock().medId(id = UUID.randomUUID())
+        val soeknad3 = soeknadMock().medId(id = UUID.randomUUID())
         val vedtaksperiodeId = UUID.randomUUID()
         val vedtaksperiodeId2 = UUID.randomUUID()
 
@@ -125,7 +126,7 @@ class SoeknadRepositoryTest {
 
     @Test
     fun `hentSoeknad skal hente søknad med id`() {
-        val soeknader = List(10) { UUID.randomUUID() }.map { id -> soeknadMock().copy(id = id) }
+        val soeknader = List(10) { UUID.randomUUID() }.map { id -> soeknadMock().medId(id = id) }
 
         soeknader.forEach { soeknadRepository.lagreSoeknad(it.tilLagreSoeknad()) }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRepositoryTest.kt
@@ -135,6 +135,13 @@ class SoeknadRepositoryTest {
     }
 
     @Test
+    fun `hentSoeknad takler at sendt-felter ikke er populert`() {
+        val soeknad = soeknadMock().copy(sendtNav = null, sendtArbeidsgiver = null)
+        soeknadRepository.lagreSoeknad(soeknad.tilLagreSoeknad())
+        soeknadRepository.hentSoeknad(soeknad.id) shouldBe soeknad
+    }
+
+    @Test
     fun `hentSoeknader skal bare hente søknader med riktig orgnr`() {
         val orgnr = Orgnr.genererGyldig()
         val soeknaderMedSammeOrgnr =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadServiceTest.kt
@@ -14,6 +14,7 @@ import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
 import no.nav.helsearbeidsgiver.kafka.soeknad.SykepengesoknadDTO
 import no.nav.helsearbeidsgiver.soeknad.SoeknadEntitet.sykepengesoeknad
 import no.nav.helsearbeidsgiver.testcontainer.WithPostgresContainer
+import no.nav.helsearbeidsgiver.utils.TestData.medId
 import no.nav.helsearbeidsgiver.utils.TestData.soeknadMock
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.jetbrains.exposed.sql.Database
@@ -259,7 +260,7 @@ class SoeknadServiceTest {
         val soeknad = soeknadMock()
         val soeknadId = UUID.randomUUID()
 
-        val soeknadSomSkalLagres = soeknad.copy(id = soeknadId)
+        val soeknadSomSkalLagres = soeknad.medId(id = soeknadId)
 
         val soeknadSomIkkeSkalLagres =
             soeknad.copy(id = soeknadId, fom = soeknad.fom?.minusDays(1))

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingAuthTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingAuthTest.kt
@@ -11,28 +11,20 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.mockk.clearMocks
 import io.mockk.every
-import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import kotlinx.coroutines.runBlocking
 import no.nav.helsearbeidsgiver.authorization.ApiTest
-import no.nav.helsearbeidsgiver.config.getPdpService
 import no.nav.helsearbeidsgiver.sykmelding.model.Sykmelding
 import no.nav.helsearbeidsgiver.utils.TestData.sykmeldingMock
 import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.ugyldigTokenManglerSystembruker
-import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class SykmeldingAuthTest : ApiTest() {
-    private val orgnrUtenPdpTilgang = Orgnr.genererGyldig().toString()
-    private val hovedenhetOrgnrMedPdpTilgang = Orgnr.genererGyldig().toString()
-    private val underenhetOrgnrMedPdpTilgang = Orgnr.genererGyldig().toString()
-
     @BeforeAll
     fun setup() {
         clearMocks(repositories.sykmeldingRepository)
@@ -325,44 +317,5 @@ class SykmeldingAuthTest : ApiTest() {
                 }
             }
         response4.status shouldBe HttpStatusCode.Unauthorized
-    }
-
-    private fun mockPdpTilganger() {
-        mockkStatic("no.nav.helsearbeidsgiver.config.ApplicationConfigKt")
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnr = orgnrUtenPdpTilgang,
-                ressurs = any(),
-            )
-        } returns false
-
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnr = match { it == hovedenhetOrgnrMedPdpTilgang || it == underenhetOrgnrMedPdpTilgang },
-                ressurs = any(),
-            )
-        } returns true
-
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnumre = match { it.contains(orgnrUtenPdpTilgang) },
-                ressurs = any(),
-            )
-        } returns false
-
-        every {
-            getPdpService().harTilgang(
-                systembruker = any(),
-                orgnumre =
-                    match {
-                        (it.contains(hovedenhetOrgnrMedPdpTilgang) || it.contains(underenhetOrgnrMedPdpTilgang)) &&
-                            !it.contains(orgnrUtenPdpTilgang)
-                    },
-                ressurs = any(),
-            )
-        } returns true
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
@@ -844,4 +844,15 @@ object TestData {
         jsonMapper.decodeFromString<Sykmelding>(sykmeldingModel)
 
     fun soeknadMock(soeknad: String = SYKEPENGESOEKNAD): SykepengesoknadDTO = soeknad.fromJson(SykepengesoknadDTO.serializer())
+
+    fun SykepengesoknadDTO.medId(id: UUID) = this.copy(id = id)
+
+    fun SykepengesoknadDTO.medOrgnr(orgnr: String) =
+        this.copy(
+            arbeidsgiver =
+                SykepengesoknadDTO.ArbeidsgiverDTO(
+                    this.arbeidsgiver?.navn,
+                    orgnr,
+                ),
+        )
 }


### PR DESCRIPTION
støtte systembruker på hovedenhet:
-legg til søk (post) med filter, deprekert gammelt get-kall
-/soeknad/id-endepunkt: sjekk tilgang i pdp på både token-orgnr og søknad-entitet

bugfix: sendt*-felt var null i søknad i noen tilfeller, la til ekstra fallback. 

slått sammen pdpMock i auth-tester
fortsatt en del duplisert kode og auth-tester, kan nok konsolidere mer etter at im med orgnr også er implementert. 