### PR TITLE
ignorer ugyldige meldinger for import

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselService.kt
@@ -165,7 +165,9 @@ class ForespoerselService(
         val hentet = forespoerselRepository.hentForespoersel(forespoersel.forespoerselId)
 
         if (hentet == null) {
-            logger().info("Forespørsel med id: ${forespoersel.forespoerselId} og status $status finnes ikke, lagrer forespørsel.")
+            logger().info(
+                "import fsp: Forespørsel med id: ${forespoersel.forespoerselId} og status $status finnes ikke, lagrer forespørsel.",
+            )
             forespoerselRepository.lagreForespoersel(
                 forespoersel = forespoersel,
                 status = status ?: Status.AKTIV,
@@ -175,13 +177,13 @@ class ForespoerselService(
         }
 
         if (status != null && hentet.status != status) {
-            logger().info("Forespørsel med id: ${forespoersel.forespoerselId} finnes, oppdaterer status til $status.")
+            logger().info("import fsp: Forespørsel med id: ${forespoersel.forespoerselId} finnes, oppdaterer status til $status.")
             forespoerselRepository.oppdaterStatus(forespoersel.forespoerselId, status)
         }
         val hentEksponertForespoerselId = hentEksponertForespoerselId(forespoersel.forespoerselId)
         if (hentEksponertForespoerselId != eksponertForespoerselId) {
             logger().info(
-                "Forespørsel med id: ${forespoersel.forespoerselId} oppdaterer eksponertForespoerselId til: $eksponertForespoerselId.",
+                "import fsp: Forespørsel med id: ${forespoersel.forespoerselId} oppdaterer eksponertForespoerselId til: $eksponertForespoerselId.",
             )
             forespoerselRepository.oppdaterEksponertForespoerselId(
                 forespoersel.forespoerselId,
@@ -190,6 +192,6 @@ class ForespoerselService(
             return
         }
 
-        logger().info("Forespørsel med id: ${forespoersel.forespoerselId} finnes, ingen oppdatering nødvendig.")
+        logger().info("import fsp: Forespørsel med id: ${forespoersel.forespoerselId} finnes, ingen oppdatering nødvendig.")
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/ForespoerselTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/ForespoerselTolker.kt
@@ -30,6 +30,10 @@ class ForespoerselTolker(
                     logger.debug("Ignorerer behov-melding")
                     return
                 } else {
+                    if (melding.contains(NotisType.FORESPOERSEL_FOR_VEDTAKSPERIODE_ID.toString())) {
+                        logger.error("Ugyldig forespørselformat! Melding n $NotisType.FORESPOERSEL_FOR_VEDTAKSPERIODE_ID")
+                        return
+                    }
                     sikkerLogger.error("Ugyldig forespørselformat!", e)
                     throw e
                 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/ForespoerselTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/ForespoerselTolker.kt
@@ -31,7 +31,7 @@ class ForespoerselTolker(
                     return
                 } else {
                     if (melding.contains(NotisType.FORESPOERSEL_FOR_VEDTAKSPERIODE_ID.toString())) {
-                        logger.error("Ugyldig forespørselformat! Melding n $NotisType.FORESPOERSEL_FOR_VEDTAKSPERIODE_ID")
+                        logger.error("Ugyldig forespørselformat! Melding  ${NotisType.FORESPOERSEL_FOR_VEDTAKSPERIODE_ID}")
                         return
                     }
                     sikkerLogger.error("Ugyldig forespørselformat!", e)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/ForespoerselTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/ForespoerselTolker.kt
@@ -31,7 +31,8 @@ class ForespoerselTolker(
                     return
                 } else {
                     if (melding.contains(NotisType.FORESPOERSEL_FOR_VEDTAKSPERIODE_ID.toString())) {
-                        logger.error("Ugyldig forespørselformat! Melding  ${NotisType.FORESPOERSEL_FOR_VEDTAKSPERIODE_ID}")
+                        logger.error("import fsp: Ugyldig forespørselformat! Melding  ${NotisType.FORESPOERSEL_FOR_VEDTAKSPERIODE_ID}")
+                        sikkerLogger.error("import fsp: Ugyldig forespørselformat! Melding", e)
                         return
                     }
                     sikkerLogger.error("Ugyldig forespørselformat!", e)
@@ -103,14 +104,16 @@ class ForespoerselTolker(
             }
 
             NotisType.FORESPOERSEL_FOR_VEDTAKSPERIODE_ID -> {
-                logger.info("Forespørsel for vedtaksperiodeId mottat")
+                logger.info("import fsp: Forespørsel for vedtaksperiodeId mottat")
                 obj.forespoersel?.let { forespoersel ->
                     logger.info(
-                        "Lagrer eller oppdaterer forespørsel med id: ${forespoersel.forespoerselId} for vedtaksperiodeId: ${forespoersel.vedtaksperiodeId}",
+                        "import fsp: Lagrer eller oppdaterer forespørsel med id: ${forespoersel.forespoerselId} for vedtaksperiodeId: ${forespoersel.vedtaksperiodeId}",
                     )
 
                     obj.eksponertForespoerselId?.let { forespoerselService.lagreEllerOppdaterForespoersel(forespoersel, obj.status, it) }
-                        ?: logger.error("Eksponert forespørsel ID er null for forespørsel med id: ${forespoersel.forespoerselId}")
+                        ?: logger.error(
+                            "import fsp: Eksponert forespørsel ID er null for forespørsel med id: ${forespoersel.forespoerselId}",
+                        )
                 }
             }
         }


### PR DESCRIPTION
Egen feilhåndtering som ignorer ugyldige meldinger fra import-jobben. Disse blir logget i lps-api  og tatt vare på i klienten for å undersøke senere.
Forbedret logging for å kunne spore innkommende meldinger.

