### PR TITLE
tmp fix: gjør Type nullable i forespørsel

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/pri/PriMessage.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/pri/PriMessage.kt
@@ -28,7 +28,7 @@ Kopierte domeneobjekter fra BRO. Skal ikke eksponeres mot LPS, brukes for å tol
  */
 @Serializable
 data class ForespoerselDokument(
-    val type: Type,
+    val type: Type? = null,
     val orgnr: String,
     val fnr: String,
     val vedtaksperiodeId: UUID,


### PR DESCRIPTION
Endrer parsing av forespørsel fra bro til å tillate manglende Type-felt pga en oppdatering i Bro. 
Kjører i prod for å lese inn payloads uten Type fram til vi er ajour på topic, deretter rulles denne tilbake. 

