### PR TITLE
Fjern ubrukt type-felt fra forespørsel

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/pri/PriMessage.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/pri/PriMessage.kt
@@ -33,6 +33,6 @@ data class ForespoerselDokument(
     val vedtaksperiodeId: UUID,
     val egenmeldingsperioder: List<Periode>,
     val sykmeldingsperioder: List<Periode>,
-    val bestemmendeFravaersdager: Map<Orgnr, LocalDate>,
+    val bestemmendeFravaersdager: Map<Orgnr, LocalDate> = emptyMap(),
     val forespurtData: ForespurtData,
 )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/pri/PriMessage.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/forespoersel/pri/PriMessage.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.forespoersel.ForespurtData
 import no.nav.helsearbeidsgiver.forespoersel.Status
-import no.nav.helsearbeidsgiver.forespoersel.Type
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
@@ -28,13 +27,12 @@ Kopierte domeneobjekter fra BRO. Skal ikke eksponeres mot LPS, brukes for å tol
  */
 @Serializable
 data class ForespoerselDokument(
-    val type: Type,
     val orgnr: String,
     val fnr: String,
-    val vedtaksperiodeId: UUID,
     val forespoerselId: UUID,
-    val sykmeldingsperioder: List<Periode>,
+    val vedtaksperiodeId: UUID,
     val egenmeldingsperioder: List<Periode>,
+    val sykmeldingsperioder: List<Periode>,
+    val bestemmendeFravaersdager: Map<Orgnr, LocalDate>,
     val forespurtData: ForespurtData,
-    val bestemmendeFravaersdager: Map<Orgnr, LocalDate>? = null,
 )

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.utils
 import no.nav.helsearbeidsgiver.forespoersel.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.forespoersel.ForespurtData
 import no.nav.helsearbeidsgiver.forespoersel.Inntekt
-import no.nav.helsearbeidsgiver.forespoersel.Type
 import no.nav.helsearbeidsgiver.kafka.forespoersel.pri.ForespoerselDokument
 import no.nav.helsearbeidsgiver.kafka.soeknad.SykepengesoknadDTO
 import no.nav.helsearbeidsgiver.sykmelding.SendSykmeldingAivenKafkaMessage
@@ -823,13 +822,13 @@ object TestData {
         fnr: String,
         forespoerselId: UUID = UUID.randomUUID(),
     ) = ForespoerselDokument(
-        type = Type.KOMPLETT,
         orgnr = orgnr,
         fnr = fnr,
-        vedtaksperiodeId = UUID.randomUUID(),
         forespoerselId = forespoerselId,
-        sykmeldingsperioder = emptyList(),
+        vedtaksperiodeId = UUID.randomUUID(),
         egenmeldingsperioder = emptyList(),
+        sykmeldingsperioder = emptyList(),
+        bestemmendeFravaersdager = emptyMap(),
         forespurtData =
             ForespurtData(
                 Arbeidsgiverperiode(true),


### PR DESCRIPTION
`type`-felt er fjernet fra Storebror etter å ha blitt utdatert i Simba for lenge siden.