### PR TITLE
Returner bad request ved manglende body

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
@@ -4,6 +4,7 @@ package no.nav.helsearbeidsgiver.inntektsmelding
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ContentTransformationException
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -139,6 +140,8 @@ private fun Route.filtrerInntektsmeldinger(inntektsmeldingService: Inntektsmeldi
             return@post
         } catch (_: BadRequestException) {
             call.respond(HttpStatusCode.BadRequest, "Ugyldig filterparameter")
+        } catch (_: ContentTransformationException) {
+            call.respond(HttpStatusCode.BadRequest, "Request mangler eller har ugyldig body")
         } catch (e: Exception) {
             sikkerLogger().error("Feil ved henting av inntektsmeldinger: {$e}")
             call.respond(HttpStatusCode.InternalServerError, "Feil ved henting av inntektsmeldinger")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
@@ -2,6 +2,7 @@ package no.nav.helsearbeidsgiver.soeknad
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ContentTransformationException
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -89,6 +90,8 @@ private fun Route.filtrerSoeknader(soeknadService: SoeknadService) {
             return@post
         } catch (_: BadRequestException) {
             call.respond(HttpStatusCode.BadRequest, "Ugyldig filterparameter")
+        } catch (_: ContentTransformationException) {
+            call.respond(HttpStatusCode.BadRequest, "Request mangler eller har ugyldig body")
         } catch (e: Exception) {
             sikkerLogger().error("Feil ved henting av sykepengesøknader", e)
             call.respond(HttpStatusCode.InternalServerError, "Feil ved henting av sykepengesøknader")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRouting.kt
@@ -3,6 +3,7 @@ package no.nav.helsearbeidsgiver.sykmelding
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.HttpStatusCode.Companion.NotFound
 import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ContentTransformationException
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -93,6 +94,8 @@ private fun Route.filtrerSykmeldinger(sykmeldingService: SykmeldingService) {
             call.respond(HttpStatusCode.BadRequest, "Ugyldig identifikator")
         } catch (_: BadRequestException) {
             call.respond(HttpStatusCode.BadRequest, "Ugyldig filterparameter")
+        } catch (_: ContentTransformationException) {
+            call.respond(HttpStatusCode.BadRequest, "Request mangler eller har ugyldig body")
         } catch (e: Exception) {
             sikkerLogger().error("Feil ved henting av sykmeldinger", e)
             call.respond(HttpStatusCode.InternalServerError, "Feil ved henting av sykmeldinger")

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRoutingTest.kt
@@ -221,6 +221,18 @@ class InntektsmeldingRoutingTest : ApiTest() {
     }
 
     @Test
+    fun `gir 400 dersom request mangler body`() {
+        runBlocking {
+            val response =
+                client.post("/v1/inntektsmeldinger") {
+                    contentType(ContentType.Application.Json)
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
+                }
+            response.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
+    @Test
     fun `gir 400 dersom man ber om inntektsmeldinger for skrekkelig langt inn i fremtiden`() {
         runBlocking {
             val response =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRoutingTest.kt
@@ -142,6 +142,21 @@ class SoeknadRoutingTest : ApiTest() {
     }
 
     @Test
+    fun `gir 400 dersom request mangler body`() {
+        val filter = SykepengesoeknadFilter(orgnr = DEFAULT_ORG)
+        every { repositories.soeknadRepository.hentSoeknader(filter) } returns emptyList()
+
+        runBlocking {
+            val respons =
+                client.post("/v1/sykepengesoeknader") {
+                    contentType(ContentType.Application.Json)
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
+                }
+            respons.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
+    @Test
     fun `gir 400 dersom man ber om søknader for skrekkelig langt inn i fremtiden`() {
         val filter = SykepengesoeknadFilter(orgnr = DEFAULT_ORG)
         every { repositories.soeknadRepository.hentSoeknader(filter) } returns emptyList()

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
@@ -173,6 +173,21 @@ class SykmeldingRoutingTest : ApiTest() {
     }
 
     @Test
+    fun `gir 400 dersom request mangler body`() {
+        val filter = SykmeldingFilter(orgnr = DEFAULT_ORG)
+        every { repositories.sykmeldingRepository.hentSykmeldinger(filter) } returns emptyList()
+
+        runBlocking {
+            val response =
+                client.post("/v1/sykmeldinger") {
+                    contentType(ContentType.Application.Json)
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
+                }
+            response.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
+    @Test
     fun `gir 400 dersom man ber om sykmeldinger for skrekkelig langt inn i fremtiden`() {
         val filter = SykmeldingFilter(orgnr = DEFAULT_ORG)
         every { repositories.sykmeldingRepository.hentSykmeldinger(filter) } returns emptyList()


### PR DESCRIPTION
Så i loggene at vi fikk mange errors fordi en del sendte inn requester uten body i dev. 
Disse returnerte også 500 så litt misvisende siden det egentlig er client feil.
Catcher dette og returner bad request istedenfor.