### PR TITLE
legger til errorlogging når forespørsel ikke finnes ved status endring

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselService.kt
@@ -78,7 +78,7 @@ class ForespoerselService(
         val forespoersel =
             forespoerselRepository.hentForespoersel(navReferanseId)
                 ?: run {
-                    sikkerLogger().info("Forespørsel med id: $navReferanseId finnes ikke, kan ikke oppdatere status til BESVART")
+                    sikkerLogger().error("Forespørsel med id: $navReferanseId finnes ikke, kan ikke oppdatere status til BESVART")
                     return
                 }
 
@@ -115,6 +115,11 @@ class ForespoerselService(
     }
 
     fun settForkastet(navReferanseId: UUID) {
+        forespoerselRepository.hentForespoersel(navReferanseId)
+            ?: run {
+                sikkerLogger().error("Forespørsel med id: $navReferanseId finnes ikke, kan ikke oppdatere status til FORKASTET")
+                return
+            }
         forespoerselRepository.oppdaterStatus(navReferanseId, Status.FORKASTET)
         logger().info("Oppdaterer status til FORKASTET for forespørsel med id: $navReferanseId")
     }


### PR DESCRIPTION
Denne skal ikke skje etter at vi legger til kafka-keys men vi legger til en error logg dersom det skjer for å kunne følge opp. 
