### PR TITLE
Opprett grafana mappe med csv fil som kobler lps navn til orgnr

### DIFF
--- a/grafana/orgnrNavnOppslag.csv
+++ b/grafana/orgnrNavnOppslag.csv
@@ -1,4 +1,4 @@
-navn,orgnr
-Tigersys,315339138
-Simployer,986419454
-Visma,982410339
+orgnr,navn
+315339138,Tigersys
+986419454,Simployer
+982410339,Visma


### PR DESCRIPTION
Denne brukes i Grafana for å mappe om lps navn til orgnr. 

https://grafana.nav.cloud.nais.io/d/9e816a96-28df-4273-8a1d-212496d26c81/lps-api-metrikker?orgId=1&from=now-1h&to=now&timezone=browser&var-lps_leverandor=982410339&editIndex=0&showCategory=Legend