### PR TITLE
Fjerner sikkerlogging til elastic

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -22,13 +22,10 @@ spec:
   observability:
     logging:
       destinations:
-        - id: secure_logs
         - id: loki
     autoInstrumentation:
       enabled: true
       runtime: java
-  secureLogs:
-    enabled: true
   prometheus:
     enabled: true
     path: /metrics

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -22,7 +22,6 @@ spec:
   observability:
     logging:
       destinations:
-        - id: secure_logs
         - id: loki
     autoInstrumentation:
       enabled: true
@@ -42,8 +41,6 @@ spec:
     path: /health/is-ready
     periodSeconds: 10
     timeout: 1
-  secureLogs:
-    enabled: true
   kafka:
     pool: nav-prod
 #  ingresses:

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,19 +2,6 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
-    <!-- Elastic securelogs -->
-    <appender name="secureLog" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/secure-logs/secure.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>1</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
-        </triggeringPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
     <!-- Team logger -->
     <appender name="team-logs" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
@@ -30,7 +17,6 @@
     <logger name="io.netty" level="INFO"/>
     <logger name="no.nav" level="DEBUG"/>
     <logger name="tjenestekall" level="INFO" additivity="false">
-        <appender-ref ref="secureLog" />
         <appender-ref ref="team-logs" />
     </logger>
 </configuration>


### PR DESCRIPTION
Elastic / securelogs er deprecated, erstattet med teamlogs. 
Fjerner alle referanser til gammel securelogs i logg-konfigs