### PR TITLE
Legger til statussjekk i fetchWithRetry for integrasjonstester

### DIFF
--- a/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ApplicationTest.kt
@@ -246,8 +246,8 @@ class ApplicationTest : LpsApiIntegrasjontest() {
         sendKafkaMelding(buildForespoerselOppdatertJson(oppdatertForespoerselId, forespoerselId))
 
         runBlocking {
-            val oppdatertFsp = hentForespoerselFraApi(oppdatertForespoerselId)
-            val forespoerselSvar = hentForespoerselFraApi(forespoerselId)
+            val oppdatertFsp = sjekkForespoerselStatus(oppdatertForespoerselId, Status.AKTIV)
+            val forespoerselSvar = sjekkForespoerselStatus(forespoerselId, Status.FORKASTET)
 
             forespoerselSvar.navReferanseId shouldBe forespoerselId
             oppdatertFsp.navReferanseId shouldBe oppdatertForespoerselId
@@ -284,13 +284,13 @@ class ApplicationTest : LpsApiIntegrasjontest() {
         sendKafkaMelding(buildForespoerselOppdatertJson(oppdatertForespoerselId, forespoerselId, vedtaksperiodeId))
 
         runBlocking {
-            val oppdatertFsp = hentForespoerselFraApi(oppdatertForespoerselId)
+            val oppdatertFsp = sjekkForespoerselStatus(oppdatertForespoerselId, Status.AKTIV)
             oppdatertFsp.navReferanseId shouldBe oppdatertForespoerselId
             oppdatertFsp.status shouldBe Status.AKTIV
 
             sjekkForespoerselEntitetIDb(oppdatertForespoerselId, forespoerselId)
 
-            val forespoerselSvar = hentForespoerselFraApi(forespoerselId)
+            val forespoerselSvar = sjekkForespoerselStatus(forespoerselId, Status.BESVART)
             forespoerselSvar.navReferanseId shouldBe forespoerselId
             forespoerselSvar.status shouldBe Status.BESVART
         }
@@ -320,11 +320,11 @@ class ApplicationTest : LpsApiIntegrasjontest() {
         sendKafkaMelding(buildForspoerselBesvartMelding(oppdatertForespoerselId))
 
         runBlocking {
-            val oppdatertFsp = hentForespoerselFraApi(oppdatertForespoerselId)
+            val oppdatertFsp = sjekkForespoerselStatus(oppdatertForespoerselId, Status.BESVART)
             oppdatertFsp.navReferanseId shouldBe oppdatertForespoerselId
             oppdatertFsp.status shouldBe Status.BESVART
 
-            val forespoersel = hentForespoerselFraApi(forespoerselId)
+            val forespoersel = sjekkForespoerselStatus(forespoerselId, Status.FORKASTET)
             forespoersel.navReferanseId shouldBe forespoerselId
             forespoersel.status shouldBe Status.FORKASTET
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/ApplicationTest.kt
@@ -342,13 +342,13 @@ class ApplicationTest : LpsApiIntegrasjontest() {
         sendKafkaMelding(buildForespoerselOppdatertJson(oppdatertForespoerselId2, forespoerselId, vedtaksperiodeId))
         sendKafkaMelding(buildForspoerselBesvartMelding(forespoerselId))
         runBlocking {
-            sjekkeForespoerselStatus(forespoerselId, Status.FORKASTET).status shouldBe Status.FORKASTET
-            sjekkeForespoerselStatus(oppdatertForespoerselId1, Status.FORKASTET).status shouldBe Status.FORKASTET
-            sjekkeForespoerselStatus(oppdatertForespoerselId2, Status.BESVART).status shouldBe Status.BESVART
+            sjekkForespoerselStatus(forespoerselId, Status.FORKASTET).status shouldBe Status.FORKASTET
+            sjekkForespoerselStatus(oppdatertForespoerselId1, Status.FORKASTET).status shouldBe Status.FORKASTET
+            sjekkForespoerselStatus(oppdatertForespoerselId2, Status.BESVART).status shouldBe Status.BESVART
         }
     }
 
-    private suspend fun sjekkeForespoerselStatus(
+    private suspend fun sjekkForespoerselStatus(
         forespoerselId: UUID?,
         status: Status,
     ): Forespoersel =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/testcontainer/LpsApiIntegrasjontest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/testcontainer/LpsApiIntegrasjontest.kt
@@ -97,10 +97,17 @@ abstract class LpsApiIntegrasjontest {
         server.stop()
     }
 
+    /**
+     * `betingelse` er en suspenderende lambda som får HTTP-responsen og skal returnere `true`
+     * når ønsket tilstand er oppnådd. Retry-løkken stopper tidlig hvis responsen har status 200
+     * og `betingelse` returnerer `true`. Bruk denne for å vente på en spesifikk tilstand i responsen.
+     */
     suspend fun fetchWithRetry(
         url: String,
         token: String,
-        betingelse: suspend (HttpResponse) -> Boolean = { true },
+        betingelse: suspend (HttpResponse) -> Boolean = {
+            true
+        },
         maxAttempts: Int = 5,
         delayMillis: Long = 100L,
     ): HttpResponse {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/testcontainer/LpsApiIntegrasjontest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/testcontainer/LpsApiIntegrasjontest.kt
@@ -100,29 +100,7 @@ abstract class LpsApiIntegrasjontest {
     suspend fun fetchWithRetry(
         url: String,
         token: String,
-        maxAttempts: Int = 5,
-        delayMillis: Long = 100L,
-    ): HttpResponse {
-        var attempts = 0
-        lateinit var response: HttpResponse
-
-        do {
-            attempts++
-            response =
-                client.get(url) {
-                    bearerAuth(token)
-                }
-            if (response.status.value == 200) break
-            delay(delayMillis)
-        } while (attempts < maxAttempts)
-
-        return response
-    }
-
-    suspend fun fetchWithRetry(
-        url: String,
-        token: String,
-        betingelse: suspend (HttpResponse) -> Boolean,
+        betingelse: suspend (HttpResponse) -> Boolean = { true },
         maxAttempts: Int = 5,
         delayMillis: Long = 100L,
     ): HttpResponse {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/testcontainer/LpsApiIntegrasjontest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/testcontainer/LpsApiIntegrasjontest.kt
@@ -118,4 +118,27 @@ abstract class LpsApiIntegrasjontest {
 
         return response
     }
+
+    suspend fun fetchWithRetry(
+        url: String,
+        token: String,
+        betingelse: suspend (HttpResponse) -> Boolean,
+        maxAttempts: Int = 5,
+        delayMillis: Long = 100L,
+    ): HttpResponse {
+        var attempts = 0
+        lateinit var response: HttpResponse
+
+        do {
+            attempts++
+            response =
+                client.get(url) {
+                    bearerAuth(token)
+                }
+            if (response.status.value == 200 && betingelse(response)) break
+            delay(delayMillis)
+        } while (attempts < maxAttempts)
+
+        return response
+    }
 }


### PR DESCRIPTION
Endret funksjonen fetchWithRetry til å få inn en betingelse som sjekker i tilleg til httpsStatus.
Denne vil gjøre at funksjonen prøver på nytt dersom meldingen ikke er prosessert.