### PR TITLE
Endrer logg melding til warn

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselService.kt
@@ -78,7 +78,7 @@ class ForespoerselService(
         val forespoersel =
             forespoerselRepository.hentForespoersel(navReferanseId)
                 ?: run {
-                    sikkerLogger().error("Forespørsel med id: $navReferanseId finnes ikke, kan ikke oppdatere status til BESVART")
+                    sikkerLogger().warn("Forespørsel med id: $navReferanseId finnes ikke, kan ikke oppdatere status til BESVART")
                     return
                 }
 
@@ -117,7 +117,7 @@ class ForespoerselService(
     fun settForkastet(navReferanseId: UUID) {
         forespoerselRepository.hentForespoersel(navReferanseId)
             ?: run {
-                sikkerLogger().error("Forespørsel med id: $navReferanseId finnes ikke, kan ikke oppdatere status til FORKASTET")
+                sikkerLogger().warn("Forespørsel med id: $navReferanseId finnes ikke, kan ikke oppdatere status til FORKASTET")
                 return
             }
         forespoerselRepository.oppdaterStatus(navReferanseId, Status.FORKASTET)


### PR DESCRIPTION
Endrer loggmelding til warn dersom forespørsel ikke finnes ved oppdatering av status

Bakgrunn:
Vi begynte å lagre forespørsler i produksjon fra og med 10.04.2025. Dersom det kommer en oppdatering av status for forespørsler som er eldre enn dette, vil oppdateringen feile fordi forespørselen ikke finnes.

Vi har sett en del slike tilfeller i det siste, og for å unngå unødvendig støy i loggene har vi valgt å endre loggnivået fra error til warn i disse tilfellene.