### PR TITLE
Konsumer sykmeldinger i prod

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
@@ -245,15 +245,14 @@ fun Application.configureKafkaConsumers(
         )
     }
 
-    if (unleashFeatureToggles.skalKonsumereSykmeldinger()) {
-        val sykmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("sm"))
-        launch(Dispatchers.Default) {
-            startKafkaConsumer(
-                topic = getProperty("kafkaConsumer.sykmelding.topic"),
-                consumer = sykmeldingKafkaConsumer,
-                meldingTolker = tolkere.sykmeldingTolker,
-            )
-        }
+    val sykmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("sm"))
+    launch(Dispatchers.Default) {
+        startKafkaConsumer(
+            topic = getProperty("kafkaConsumer.sykmelding.topic"),
+            consumer = sykmeldingKafkaConsumer,
+            meldingTolker = tolkere.sykmeldingTolker,
+            unleashFeatureToggles::skalKonsumereSykmeldinger
+        )
     }
 
     if (unleashFeatureToggles.skalKonsumereSykepengesoeknader()) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/config/ApplicationConfig.kt
@@ -251,7 +251,7 @@ fun Application.configureKafkaConsumers(
             topic = getProperty("kafkaConsumer.sykmelding.topic"),
             consumer = sykmeldingKafkaConsumer,
             meldingTolker = tolkere.sykmeldingTolker,
-            unleashFeatureToggles::skalKonsumereSykmeldinger
+            unleashFeatureToggles::skalKonsumereSykmeldinger,
         )
     }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/KafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/KafkaConsumer.kt
@@ -22,7 +22,7 @@ suspend fun startKafkaConsumer(
     consumer.asFlow().collect { record ->
         try {
             consumer.toggleConsumer(enabled, topic)
-            if(!enabled()) {
+            if (!enabled()) {
                 return@collect
             }
             // Obs: record.value() kan være null fordi det er implementert i Java
@@ -55,7 +55,11 @@ suspend fun startKafkaConsumer(
         }
     }
 }
-fun <K, V> KafkaConsumer<K, V>.toggleConsumer(enabled: () -> Boolean, topic: String){
+
+fun <K, V> KafkaConsumer<K, V>.toggleConsumer(
+    enabled: () -> Boolean,
+    topic: String,
+) {
     val konsumeringPauset = this.paused().isNotEmpty()
     if (!enabled() && !konsumeringPauset) {
         logger().warn("Pauser konsumering av topic $topic}")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/KafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/KafkaConsumer.kt
@@ -1,7 +1,9 @@
 package no.nav.helsearbeidsgiver.kafka
 
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -74,7 +76,7 @@ fun <K, V> KafkaConsumer<K, V>.asFlow(
     timeout: Duration = Duration.ofMillis(10),
 ): Flow<ConsumerRecord<K, V>> =
     flow {
-        while (true) {
+        while (currentCoroutineContext().isActive) {
             toggleSjekk()
             poll(timeout).forEach { emit(it) }
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/KafkaConsumerIT.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/integrasjonstest/KafkaConsumerIT.kt
@@ -1,0 +1,62 @@
+package no.nav.helsearbeidsgiver.integrasjonstest
+
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import no.nav.helsearbeidsgiver.Env.getProperty
+import no.nav.helsearbeidsgiver.Producer
+import no.nav.helsearbeidsgiver.kafka.createKafkaConsumerConfig
+import no.nav.helsearbeidsgiver.kafka.startKafkaConsumer
+import no.nav.helsearbeidsgiver.kafka.sykmelding.SykmeldingTolker
+import no.nav.helsearbeidsgiver.testcontainer.WithKafkaContainer
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.text.set
+
+@WithKafkaContainer
+class KafkaConsumerIT {
+    @Test
+    fun enkeltEksempel() =
+        runTest {
+            val sykmeldingTolker = mockk<SykmeldingTolker>()
+            every { sykmeldingTolker.lesMelding(any()) } just runs
+
+            val sykmeldingKafkaConsumer = KafkaConsumer<String, String>(createKafkaConsumerConfig("sm"))
+            val topic = getProperty("kafkaConsumer.sykmelding.topic")
+
+            val toggle = AtomicBoolean(true)
+
+            val consumerJob =
+                launch(Dispatchers.IO) {
+                    startKafkaConsumer(
+                        topic = topic,
+                        consumer = sykmeldingKafkaConsumer,
+                        meldingTolker = sykmeldingTolker,
+                        { toggle.get() },
+                    )
+                }
+
+            Producer.sendMelding(ProducerRecord(topic, "key", "{\"hello\":\"world 1\"}"))
+
+            coVerify(timeout = 5000, exactly = 1) { sykmeldingTolker.lesMelding(any()) }
+
+            runBlocking {
+                toggle.set(false)
+                Producer.sendMelding(ProducerRecord(topic, "key", "{\"hello\":\"world 2\"}"))
+                kotlinx.coroutines.delay(1000)
+                verify(exactly = 1) { sykmeldingTolker.lesMelding(any()) }
+            }
+
+            consumerJob.cancelAndJoin()
+        }
+}

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/KafkaConsumerUtilsTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/KafkaConsumerUtilsTest.kt
@@ -1,0 +1,31 @@
+package no.nav.helsearbeidsgiver.utils
+
+import io.kotest.matchers.shouldBe
+import no.nav.helsearbeidsgiver.kafka.erInnenforSiste2Aar
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class KafkaConsumerUtilsTest {
+    @Test
+    fun `timestamp innenfor siste to år returnerer true`() {
+        val innenfor =
+            Instant
+                .now()
+                .minus(300, ChronoUnit.DAYS)
+                .toEpochMilli()
+
+        innenfor.erInnenforSiste2Aar() shouldBe true
+    }
+
+    @Test
+    fun `timestamp innenfor siste to år returnerer false`() {
+        val utenfor =
+            Instant
+                .now()
+                .minus(365 * 2 + 10, ChronoUnit.DAYS)
+                .toEpochMilli()
+
+        utenfor.erInnenforSiste2Aar() shouldBe false
+    }
+}


### PR DESCRIPTION
Vi bruker timestamp i kafka metadata for å unngå poisonpills 💊 .
Tar også i bruk uneashed feature toggle slik at vi kan stoppe og starte consumer uten å restarte applikasjonen.