### PR TITLE
Fjern missvisende loggmelding hvor det ser ut som vi alltid lager dialog

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/sykmelding/SykmeldingTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/sykmelding/SykmeldingTolker.kt
@@ -31,8 +31,6 @@ class SykmeldingTolker(
 
             val harLagretSykmelding = sykmeldingService.lagreSykmelding(sykmeldingMessage, sykmeldingId, fullPerson.navn.fulltNavn())
 
-            logger.info("Lagret sykmelding til database med id: $sykmeldingId")
-
             if (harLagretSykmelding) {
                 val dialogSykmelding =
                     DialogSykmelding(
@@ -43,7 +41,6 @@ class SykmeldingTolker(
                         sykmeldingsperioder = sykmeldingMessage.sykmelding.sykmeldingsperioder.map { Periode(it.fom, it.tom) },
                     )
                 dialogportenService.opprettNyDialogMedSykmelding(dialogSykmelding)
-                logger.info("Opprettet dialog for sykmelding $sykmeldingId")
             } else {
                 logger
                     .info(


### PR DESCRIPTION
Vi har logging inne i `sykmeldingService.lagreSykmelding(...)` og `dialogportenService.opprettNyDialogMedSykmelding` som faktisk forteller om vi lagrer eller oppretter dialog.