### PR TITLE
OpenAPI bytt PDF format byte til binary

### DIFF
--- a/openApiTasks.gradle.kts
+++ b/openApiTasks.gradle.kts
@@ -176,6 +176,8 @@ tags:
                 removeGroup("/intern/personbruker/sykmelding/{sykmeldingId}/pdf:"),
                 // Fjern depricated endepunkt
                 removeGroup("/v1/sykmelding/{sykmeldingId}.pdf:"),
+                // Endre PDF format fra byte til binary
+                Regex("""(application/pdf:\s*schema:\s*type:\s*"string"\s*format:\s*)"byte"""") to """$1"binary"""",
             )
 
         var newContent = content

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -363,7 +363,7 @@ paths:
             application/pdf:
               schema:
                 type: "string"
-                format: "byte"
+                format: "binary"
   /v1/sykepengesoeknader:
     post:
       tags:
@@ -496,7 +496,7 @@ paths:
             application/pdf:
               schema:
                 type: "string"
-                format: "byte"
+                format: "binary"
         "500":
           description: "Internal Server Error"
           content:


### PR DESCRIPTION
Ifølge [dokumentasjonen for OpenAPI](https://swagger.io/docs/specification/v3_0/data-models/data-types/#files) så skal:
```
format: binary # binary file contents
format: byte # base64-encoded file contents
```
Vår PDF fil sendes i binær form og ikke base64 slik at binary blir riktig for oss.

Er litt forvirrende fordi i [kotlin er det en "byte array"](https://api.ktor.io/ktor-server-core/io.ktor.server.response/respond-bytes.html), men i OpenAPI brukes byte for base64 encodet filer.