### PR TITLE
Bedre feilmeldinger ved JSON body serialisering

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/Forespoersel.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/Forespoersel.kt
@@ -90,11 +90,11 @@ data class ForespoerselFilter(
     val fraLoepenr: Long? = null,
 ) {
     init {
-        orgnr?.let { require(erGyldig(orgnr)) }
-        fom?.year?.let { require(it >= 0) }
-        tom?.year?.let { require(it <= 9999) } // Om man tillater alt opp til LocalDate.MAX
+        require(erGyldig(orgnr)) { "ikke et gyldig orgnr" }
+        fom?.year?.let { require(it >= 0) { "fom kan ikke være mindre enn år 0" } }
+        tom?.year?.let { require(it <= 9999) { "tom kan ikke være etter år 9999" } } // Om man tillater alt opp til LocalDate.MAX
         // vil det bli long-overflow ved konvertering til exposed sql-javadate i db-spørring
-        fraLoepenr?.let { require(it >= 0) }
+        fraLoepenr?.let { require(it >= 0) { "fraLoepenr kan ikke være mindre enn 0" } }
     }
 }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselRouting.kt
@@ -21,6 +21,7 @@ import no.nav.helsearbeidsgiver.plugins.ErrorResponse
 import no.nav.helsearbeidsgiver.plugins.Feil
 import no.nav.helsearbeidsgiver.plugins.FeilMedReferanse
 import no.nav.helsearbeidsgiver.plugins.respondWithMaxLimit
+import no.nav.helsearbeidsgiver.plugins.serialiseringsErrorResponse
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
@@ -127,10 +128,10 @@ private fun Route.filtrerForespoersler(
             return@post
         } catch (_: IllegalArgumentException) {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_IDENTIFIKATOR))
+        } catch (e: BadRequestException) {
+            call.respond(HttpStatusCode.BadRequest, serialiseringsErrorResponse(e))
         } catch (_: ContentTransformationException) {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_REQUEST_BODY))
-        } catch (_: BadRequestException) {
-            call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_FILTERPARAMETER))
         } catch (e: Exception) {
             sikkerLogger().error(Feil.FEIL_VED_HENTING_FORESPOERSLER.feilmelding, e)
             call.respond(HttpStatusCode.InternalServerError, ErrorResponse(Feil.FEIL_VED_HENTING_FORESPOERSLER))

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingResponse.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingResponse.kt
@@ -135,11 +135,11 @@ data class InntektsmeldingFilter(
     val fraLoepenr: Long? = null,
 ) {
     init {
-        require(erGyldig(orgnr))
-        fom?.year?.let { require(it >= 0) }
-        tom?.year?.let { require(it <= 9999) } // Om man tillater alt opp til LocalDate.MAX
+        require(erGyldig(orgnr)) { "ikke et gyldig orgnr" }
+        fom?.year?.let { require(it >= 0) { "fom kan ikke være mindre enn år 0" } }
+        tom?.year?.let { require(it <= 9999) { "tom kan ikke være etter år 9999" } } // Om man tillater alt opp til LocalDate.MAX
         // vil det bli long-overflow ved konvertering til exposed sql-javadate i db-spørring
-        fraLoepenr?.let { require(it >= 0) }
+        fraLoepenr?.let { require(it >= 0) { "fraLoepenr kan ikke være mindre enn 0" } }
     }
 }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
@@ -26,6 +26,7 @@ import no.nav.helsearbeidsgiver.plugins.ErrorResponse
 import no.nav.helsearbeidsgiver.plugins.Feil
 import no.nav.helsearbeidsgiver.plugins.FeilMedReferanse
 import no.nav.helsearbeidsgiver.plugins.respondWithMaxLimit
+import no.nav.helsearbeidsgiver.plugins.serialiseringsErrorResponse
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.erDuplikat
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
@@ -162,6 +163,10 @@ private fun Route.sendInntektsmelding(
 
             services.opprettImTransaction(inntektsmelding, innsending)
             call.respond(HttpStatusCode.Created, InnsendingResponse(inntektsmelding.id.toString()))
+        } catch (e: BadRequestException) {
+            call.respond(HttpStatusCode.BadRequest, serialiseringsErrorResponse(e))
+        } catch (_: ContentTransformationException) {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_REQUEST_BODY))
         } catch (e: Exception) {
             sikkerLogger().error("Feil ved lagring av innsending: {$e}", e)
             call.respond(HttpStatusCode.InternalServerError, ErrorResponse(Feil.EN_FEIL_OPPSTOD))

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
@@ -207,8 +207,8 @@ private fun Route.filtrerInntektsmeldinger(
             tellDokumenterHentet(lpsOrgnr, MetrikkDokumentType.INNTEKTSMELDING, inntektsmeldinger.size)
             call.respondWithMaxLimit(inntektsmeldinger)
             return@post
-        } catch (_: BadRequestException) {
-            call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_FILTERPARAMETER))
+        } catch (e: BadRequestException) {
+            call.respond(HttpStatusCode.BadRequest, serialiseringsErrorResponse(e))
         } catch (_: ContentTransformationException) {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_REQUEST_BODY))
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
@@ -38,6 +38,7 @@ fun serialiseringsErrorResponse(exception: Exception): ErrorResponse {
             ?.take(300)
             ?.replace(Regex(""" for type with serial name '[^']+'"""), "")
             ?.replace(Regex("""java\.\S+:\s*"""), "")
+            ?.replace(Regex("""no\.nav\.\S+\.([^.\s]+\.[^.\s]+)"""), "$1")
 
     val tillatteRegex =
         listOf(
@@ -46,25 +47,26 @@ fun serialiseringsErrorResponse(exception: Exception): ErrorResponse {
             Regex("""Illegal input: Field '.{0,100}' is required, but it was missing.*"""),
             Regex("""Illegal input: Fields \[.{0,300}] are required, but they were missing.*"""),
             Regex("""Illegal input: Text '.*' could not be parsed.*"""),
+            Regex("""Illegal input: .{0,100} does not contain element with name '.{0,10}' at path .*"""),
             Regex("""Illegal input: ikke et gyldig orgnr"""),
             Regex("""Illegal input: .{0,50} må være.*"""),
         )
 
-    val erTilattException = exceptionMelding != null && tillatteRegex.any { it.matches(exceptionMelding) }
+//    val erTilattException = exceptionMelding != null && tillatteRegex.any { it.matches(exceptionMelding) }
+    val erTilattException = exceptionMelding != null
 
     return ErrorResponse(
         feilkode = Feil.SERIALISERINGSFEIL.name,
-        feilmelding = if (erTilattException) exceptionMelding else "Feil ved serialisering av json body",
+        feilmelding = if (erTilattException) exceptionMelding else Feil.SERIALISERINGSFEIL.feilmelding,
     )
 }
 
 enum class Feil(
     val feilmelding: String,
 ) {
-    UGYLDIG_FILTERPARAMETER("Ugyldig filterparameter"),
     UGYLDIG_IDENTIFIKATOR("Ugyldig identifikator"),
-    UGYLDIG_REQUEST_BODY("Ugyldig request"),
-    SERIALISERINGSFEIL("Feil ved serialisering av json body"),
+    UGYLDIG_REQUEST_BODY("Ugyldig content type"),
+    SERIALISERINGSFEIL("Ugylding request"),
     IKKE_TILGANG_TIL_RESSURS("Ikke tilgang til ressurs"),
     EN_FEIL_OPPSTOD("En feil oppstod"),
     UAUTORISERT("Uautorisert tilgang"),

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
@@ -42,11 +42,12 @@ fun serialiseringsErrorResponse(exception: Exception): ErrorResponse {
     val tillatteRegex =
         listOf(
             Regex("""Illegal input: Unexpected JSON token at offset \d+:.*"""),
-            Regex("""Illegal input: Encountered an unknown key '.*' at offset \d+.*"""),
-            Regex("""Illegal input: Field '.*' is required, but it was missing.*"""),
-            Regex("""Illegal input: Fields \[.*] are required, but they were missing.*"""),
+            Regex("""Illegal input: Encountered an unknown key '.{0,100}' at offset \d+.*"""),
+            Regex("""Illegal input: Field '.{0,100}' is required, but it was missing.*"""),
+            Regex("""Illegal input: Fields \[.{0,300}] are required, but they were missing.*"""),
             Regex("""Illegal input: Text '.*' could not be parsed.*"""),
             Regex("""Illegal input: ikke et gyldig orgnr"""),
+            Regex("""Illegal input: .{0,50} må være.*"""),
         )
 
     val erTilattException = exceptionMelding != null && tillatteRegex.any { it.matches(exceptionMelding) }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
@@ -1,8 +1,10 @@
 package no.nav.helsearbeidsgiver.plugins
 
+import java.time.format.DateTimeParseException
 import kotlinx.serialization.Serializable
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import java.util.UUID
+import kotlinx.serialization.MissingFieldException
 
 @Serializable
 data class ErrorResponse(
@@ -27,12 +29,51 @@ fun ErrorResponse(
     referanseId = referanseId,
 )
 
+
+fun serialiseringsErrorResponse(exception: Exception): ErrorResponse {
+    val rawMessage =
+        exception
+            .cause
+            ?.message
+            ?.lines()
+            ?.firstOrNull()
+            ?: "Ukjent"
+
+    val sanitizedMessage = rawMessage
+        .replace(Regex(""" for type with serial name '[^']+'"""), "")
+        .replace(Regex("""java\.\S+:\s*"""), "")
+
+    val allowedPatterns = listOf(
+        Regex("""Unexpected JSON token at offset \d+:.*"""),
+        Regex("""Encountered an unknown key '.*' at offset \d+.*"""),
+        Regex("""Field '.*' is required, but it was missing.*"""),
+        Regex("""Text '.*' could not be parsed at index \d+"""),
+    )
+
+//    Regex("""Field '.*' is required, but it was missing.*"""), -> .replace(Regex(""" for type with serial name '[^']+'"""), "")
+
+//    Regex("""Text '.*' could not be parsed at index \d+"""), -> .replace(Regex("""java\.\S+:\s*"""), "")
+
+    val feilmelding = if (allowedPatterns.any { it.containsMatchIn(sanitizedMessage) }) {
+        sanitizedMessage
+    } else {
+        "Ugyldig request body"
+    }
+
+    return ErrorResponse(
+        feilkode = Feil.SERIALISERINGSFEIL.name,
+        feilmelding = sanitizedMessage,
+    )
+}
+
+
 enum class Feil(
     val feilmelding: String,
 ) {
     UGYLDIG_FILTERPARAMETER("Ugyldig filterparameter"),
     UGYLDIG_IDENTIFIKATOR("Ugyldig identifikator"),
     UGYLDIG_REQUEST_BODY("Ugyldig request"),
+    SERIALISERINGSFEIL("Feil ved serialisering av json body"),
     IKKE_TILGANG_TIL_RESSURS("Ikke tilgang til ressurs"),
     EN_FEIL_OPPSTOD("En feil oppstod"),
     UAUTORISERT("Uautorisert tilgang"),

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
@@ -52,8 +52,7 @@ fun serialiseringsErrorResponse(exception: Exception): ErrorResponse {
             Regex("""Illegal input: .{0,50} må være.*"""),
         )
 
-//    val erTilattException = exceptionMelding != null && tillatteRegex.any { it.matches(exceptionMelding) }
-    val erTilattException = exceptionMelding != null
+    val erTilattException = exceptionMelding != null && tillatteRegex.any { it.matches(exceptionMelding) }
 
     return ErrorResponse(
         feilkode = Feil.SERIALISERINGSFEIL.name,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
@@ -1,10 +1,10 @@
 package no.nav.helsearbeidsgiver.plugins
 
-import java.time.format.DateTimeParseException
+import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.Serializable
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
+import java.time.format.DateTimeParseException
 import java.util.UUID
-import kotlinx.serialization.MissingFieldException
 
 @Serializable
 data class ErrorResponse(
@@ -29,43 +29,32 @@ fun ErrorResponse(
     referanseId = referanseId,
 )
 
-
 fun serialiseringsErrorResponse(exception: Exception): ErrorResponse {
-    val rawMessage =
-        exception
-            .cause
+    val exceptionMelding =
+        exception.cause
             ?.message
             ?.lines()
             ?.firstOrNull()
-            ?: "Ukjent"
+            ?.take(300)
+            ?.replace(Regex(""" for type with serial name '[^']+'"""), "")
+            ?.replace(Regex("""java\.\S+:\s*"""), "")
 
-    val sanitizedMessage = rawMessage
-        .replace(Regex(""" for type with serial name '[^']+'"""), "")
-        .replace(Regex("""java\.\S+:\s*"""), "")
+    val tillatteRegex =
+        listOf(
+            Regex("""Illegal input: Unexpected JSON token at offset \d+:.*"""),
+            Regex("""Illegal input: Encountered an unknown key '.*' at offset \d+.*"""),
+            Regex("""Illegal input: Field '.*' is required, but it was missing.*"""),
+            Regex("""Illegal input: Text '.*' could not be parsed.*"""),
+            Regex("""Illegal input: ikke et gyldig orgnr"""),
+        )
 
-    val allowedPatterns = listOf(
-        Regex("""Unexpected JSON token at offset \d+:.*"""),
-        Regex("""Encountered an unknown key '.*' at offset \d+.*"""),
-        Regex("""Field '.*' is required, but it was missing.*"""),
-        Regex("""Text '.*' could not be parsed at index \d+"""),
-    )
-
-//    Regex("""Field '.*' is required, but it was missing.*"""), -> .replace(Regex(""" for type with serial name '[^']+'"""), "")
-
-//    Regex("""Text '.*' could not be parsed at index \d+"""), -> .replace(Regex("""java\.\S+:\s*"""), "")
-
-    val feilmelding = if (allowedPatterns.any { it.containsMatchIn(sanitizedMessage) }) {
-        sanitizedMessage
-    } else {
-        "Ugyldig request body"
-    }
+    val erTilattException = exceptionMelding != null && tillatteRegex.any { it.matches(exceptionMelding) }
 
     return ErrorResponse(
         feilkode = Feil.SERIALISERINGSFEIL.name,
-        feilmelding = sanitizedMessage,
+        feilmelding = if (erTilattException) exceptionMelding else "Feil ved serialisering av json body",
     )
 }
-
 
 enum class Feil(
     val feilmelding: String,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
@@ -44,6 +44,7 @@ fun serialiseringsErrorResponse(exception: Exception): ErrorResponse {
             Regex("""Illegal input: Unexpected JSON token at offset \d+:.*"""),
             Regex("""Illegal input: Encountered an unknown key '.*' at offset \d+.*"""),
             Regex("""Illegal input: Field '.*' is required, but it was missing.*"""),
+            Regex("""Illegal input: Fields \[.*] are required, but they were missing.*"""),
             Regex("""Illegal input: Text '.*' could not be parsed.*"""),
             Regex("""Illegal input: ikke et gyldig orgnr"""),
         )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/ErrorResponse.kt
@@ -49,7 +49,7 @@ fun serialiseringsErrorResponse(exception: Exception): ErrorResponse {
             Regex("""Illegal input: Text '.*' could not be parsed.*"""),
             Regex("""Illegal input: .{0,100} does not contain element with name '.{0,10}' at path .*"""),
             Regex("""Illegal input: ikke et gyldig orgnr"""),
-            Regex("""Illegal input: .{0,50} må være.*"""),
+            Regex("""Illegal input: .{0,50} kan ikke være.*"""),
         )
 
     val erTilattException = exceptionMelding != null && tillatteRegex.any { it.matches(exceptionMelding) }
@@ -65,7 +65,7 @@ enum class Feil(
 ) {
     UGYLDIG_IDENTIFIKATOR("Ugyldig identifikator"),
     UGYLDIG_REQUEST_BODY("Ugyldig content type"),
-    SERIALISERINGSFEIL("Ugylding request"),
+    SERIALISERINGSFEIL("Ugyldig request"),
     IKKE_TILGANG_TIL_RESSURS("Ikke tilgang til ressurs"),
     EN_FEIL_OPPSTOD("En feil oppstod"),
     UAUTORISERT("Uautorisert tilgang"),

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
@@ -22,6 +22,7 @@ import no.nav.helsearbeidsgiver.plugins.ErrorResponse
 import no.nav.helsearbeidsgiver.plugins.Feil
 import no.nav.helsearbeidsgiver.plugins.FeilMedReferanse
 import no.nav.helsearbeidsgiver.plugins.respondWithMaxLimit
+import no.nav.helsearbeidsgiver.plugins.serialiseringsErrorResponse
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.genererSoeknadPdf
 import no.nav.helsearbeidsgiver.utils.log.logger
@@ -150,8 +151,8 @@ private fun Route.filtrerSoeknader(
             tellDokumenterHentet(lpsOrgnr, MetrikkDokumentType.SYKEPENGESOEKNAD, soeknader.size)
             call.respondWithMaxLimit(soeknader)
             return@post
-        } catch (_: BadRequestException) {
-            call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_FILTERPARAMETER))
+        } catch (e: BadRequestException) {
+            call.respond(HttpStatusCode.BadRequest, serialiseringsErrorResponse(e))
         } catch (_: ContentTransformationException) {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_REQUEST_BODY))
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SykepengesoeknadFilter.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SykepengesoeknadFilter.kt
@@ -17,10 +17,10 @@ data class SykepengesoeknadFilter( // TODO: Kanskje denne kan de-dupliseres / ge
     val fraLoepenr: Long? = null,
 ) {
     init {
-        require(erGyldig(orgnr))
-        fom?.year?.let { require(it >= 0) }
-        tom?.year?.let { require(it <= 9999) } // Om man tillater alt opp til LocalDate.MAX
+        require(erGyldig(orgnr)) { "ikke et gyldig orgnr" }
+        fom?.year?.let { require(it >= 0) { "fom kan ikke være mindre enn år 0" } }
+        tom?.year?.let { require(it <= 9999) { "tom kan ikke være etter år 9999" } } // Om man tillater alt opp til LocalDate.MAX
         // vil det bli long-overflow ved konvertering til exposed sql-javadate i db-spørring
-        fraLoepenr?.let { require(it >= 0) }
+        fraLoepenr?.let { require(it >= 0) { "fraLoepenr kan ikke være mindre enn 0" } }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingFilter.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingFilter.kt
@@ -21,6 +21,6 @@ data class SykmeldingFilter(
         fom?.year?.let { require(it >= 0) { "fom må være før år 0" } }
         tom?.year?.let { require(it <= 9999) { "tom må være før år 9999" } } // Om man tillater alt opp til LocalDate.MAX
         // vil det bli long-overflow ved konvertering til exposed sql-javadate i db-spørring
-        fraLoepenr?.let { require(it >= 0) { "fom må være mer den 0" } }
+        fraLoepenr?.let { require(it >= 0) { "fraLoepenr må være mer den 0" } }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingFilter.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingFilter.kt
@@ -18,9 +18,9 @@ data class SykmeldingFilter(
 ) {
     init {
         require(erGyldig(orgnr)) { "ikke et gyldig orgnr" }
-        fom?.year?.let { require(it >= 0) { "fom må være før år 0" } }
-        tom?.year?.let { require(it <= 9999) { "tom må være før år 9999" } } // Om man tillater alt opp til LocalDate.MAX
+        fom?.year?.let { require(it >= 0) { "fom kan ikke være mindre enn år 0" } }
+        tom?.year?.let { require(it <= 9999) { "tom kan ikke være etter år 9999" } } // Om man tillater alt opp til LocalDate.MAX
         // vil det bli long-overflow ved konvertering til exposed sql-javadate i db-spørring
-        fraLoepenr?.let { require(it >= 0) { "fraLoepenr må være mer den 0" } }
+        fraLoepenr?.let { require(it >= 0) { "fraLoepenr kan ikke være mindre enn 0" } }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingFilter.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingFilter.kt
@@ -19,8 +19,8 @@ data class SykmeldingFilter(
     init {
         require(erGyldig(orgnr)) { "ikke et gyldig orgnr" }
         fom?.year?.let { require(it >= 0) { "fom må være før år 0" } }
-        tom?.year?.let { require(it <= 9999) { "tom må være før år 9999" }} // Om man tillater alt opp til LocalDate.MAX
+        tom?.year?.let { require(it <= 9999) { "tom må være før år 9999" } } // Om man tillater alt opp til LocalDate.MAX
         // vil det bli long-overflow ved konvertering til exposed sql-javadate i db-spørring
-        fraLoepenr?.let { require(it >= 0) { "fom må være med den 0" }}
+        fraLoepenr?.let { require(it >= 0) { "fom må være med den 0" } }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingFilter.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingFilter.kt
@@ -17,10 +17,10 @@ data class SykmeldingFilter(
     val fraLoepenr: Long? = null,
 ) {
     init {
-        require(erGyldig(orgnr))
-        fom?.year?.let { require(it >= 0) }
-        tom?.year?.let { require(it <= 9999) } // Om man tillater alt opp til LocalDate.MAX
+        require(erGyldig(orgnr)) { "ikke et gyldig orgnr" }
+        fom?.year?.let { require(it >= 0) { "fom må være før år 0" } }
+        tom?.year?.let { require(it <= 9999) { "tom må være før år 9999" }} // Om man tillater alt opp til LocalDate.MAX
         // vil det bli long-overflow ved konvertering til exposed sql-javadate i db-spørring
-        fraLoepenr?.let { require(it >= 0) }
+        fraLoepenr?.let { require(it >= 0) { "fom må være med den 0" }}
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingFilter.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingFilter.kt
@@ -21,6 +21,6 @@ data class SykmeldingFilter(
         fom?.year?.let { require(it >= 0) { "fom må være før år 0" } }
         tom?.year?.let { require(it <= 9999) { "tom må være før år 9999" } } // Om man tillater alt opp til LocalDate.MAX
         // vil det bli long-overflow ved konvertering til exposed sql-javadate i db-spørring
-        fraLoepenr?.let { require(it >= 0) { "fom må være med den 0" } }
+        fraLoepenr?.let { require(it >= 0) { "fom må være mer den 0" } }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRouting.kt
@@ -2,6 +2,7 @@ package no.nav.helsearbeidsgiver.sykmelding
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.HttpStatusCode.Companion.NotFound
+import io.ktor.serialization.JsonConvertException
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.ContentTransformationException
 import io.ktor.server.request.receive
@@ -26,6 +27,7 @@ import no.nav.helsearbeidsgiver.plugins.ErrorResponse
 import no.nav.helsearbeidsgiver.plugins.Feil
 import no.nav.helsearbeidsgiver.plugins.FeilMedReferanse
 import no.nav.helsearbeidsgiver.plugins.respondWithMaxLimit
+import no.nav.helsearbeidsgiver.plugins.serialiseringsErrorResponse
 import no.nav.helsearbeidsgiver.sykmelding.model.Sykmelding
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.genererSykmeldingPdf
@@ -169,8 +171,8 @@ private fun Route.filtrerSykmeldinger(
             return@post
         } catch (_: IllegalArgumentException) {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_IDENTIFIKATOR))
-        } catch (_: BadRequestException) {
-            call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_FILTERPARAMETER))
+        } catch (e: BadRequestException) {
+            call.respond(HttpStatusCode.BadRequest, serialiseringsErrorResponse(e))
         } catch (_: ContentTransformationException) {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_REQUEST_BODY))
         } catch (e: Exception) {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/forespoersel/ForespoerselRoutingTest.kt
@@ -5,6 +5,7 @@
 
 package no.nav.helsearbeidsgiver.forespoersel
 
+import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
 import io.ktor.client.request.bearerAuth
@@ -21,6 +22,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.authorization.ApiTest
 import no.nav.helsearbeidsgiver.config.MAX_ANTALL_I_RESPONS
+import no.nav.helsearbeidsgiver.plugins.ErrorResponse
+import no.nav.helsearbeidsgiver.plugins.Feil
 import no.nav.helsearbeidsgiver.utils.DEFAULT_ORG
 import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
@@ -293,6 +296,33 @@ class ForespoerselRoutingTest : ApiTest() {
                     bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
                 }
             response.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
+    @Test
+    fun `gir 400 Bad Request med SERIALISERINGSFEIL for ugyldige request bodies på forespoersler filter`() {
+        val tilfeller =
+            listOf(
+                """{}""",
+                """{"a": "123"}""",
+                """ikke json i det hele tatt""",
+            )
+
+        runBlocking {
+            tilfeller.forEach { body ->
+                val respons =
+                    client.post("/v1/forespoersler") {
+                        contentType(ContentType.Application.Json)
+                        setBody(body)
+                        bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
+                    }
+                val feilrespons = respons.body<ErrorResponse>()
+
+                withClue("Body: $body") {
+                    respons.status shouldBe HttpStatusCode.BadRequest
+                    feilrespons.feilkode shouldBe Feil.SERIALISERINGSFEIL.name
+                }
+            }
         }
     }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRoutingTest.kt
@@ -2,6 +2,7 @@
 
 package no.nav.helsearbeidsgiver.inntektsmelding
 
+import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
 import io.ktor.client.request.bearerAuth
@@ -22,6 +23,8 @@ import no.nav.helsearbeidsgiver.authorization.ApiTest
 import no.nav.helsearbeidsgiver.config.MAX_ANTALL_I_RESPONS
 import no.nav.helsearbeidsgiver.innsending.InnsendingStatus
 import no.nav.helsearbeidsgiver.innsending.Valideringsfeil
+import no.nav.helsearbeidsgiver.plugins.ErrorResponse
+import no.nav.helsearbeidsgiver.plugins.Feil
 import no.nav.helsearbeidsgiver.utils.DEFAULT_ORG
 import no.nav.helsearbeidsgiver.utils.buildInntektsmelding
 import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
@@ -380,4 +383,39 @@ class InntektsmeldingRoutingTest : ApiTest() {
         val orgnr: String? = null,
         val fraLoepenr: ULong? = null,
     )
+
+    @Test
+    fun `gir 400 Bad Request med SERIALISERINGSFEIL for ugyldige request bodies på inntektsmelding`() {
+        val tilfeller =
+            listOf(
+                """{}""" to
+                    "Illegal input: Fields [navReferanseId, agp, inntekt, refusjon, naturalytelser, sykmeldtFnr, aarsakInnsending, arbeidsgiverTlf, avsender] are required, but they were missing at path: \$",
+                """{"a": "123"}""" to
+                    "Illegal input: Encountered an unknown key 'a' at offset 2 at path: \$",
+                """ikke json i det hele tatt""" to
+                    "Illegal input: Unexpected JSON token at offset 0: Expected start of the object '{', but had 'i' instead at path: \$",
+                """{"navReferanseId": null}""" to
+                    "Illegal input: Unexpected JSON token at offset 23: Unexpected 'null' value instead of string literal at path: \$.navReferanseId",
+                """{"navReferanseId": {}}""" to
+                    "Illegal input: Unexpected JSON token at offset 19: Expected beginning of the string, but got { at path: \$.navReferanseId",
+            )
+
+        runBlocking {
+            tilfeller.forEach { (body, feilmeldingInneholder) ->
+                val respons =
+                    client.post("/v1/inntektsmelding") {
+                        contentType(ContentType.Application.Json)
+                        setBody(body)
+                        bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
+                    }
+                val feilrespons = respons.body<ErrorResponse>()
+
+                withClue("Body: $body") {
+                    respons.status shouldBe HttpStatusCode.BadRequest
+                    feilrespons.feilkode shouldBe Feil.SERIALISERINGSFEIL.name
+                    feilrespons.feilmelding shouldBe feilmeldingInneholder
+                }
+            }
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRoutingTest.kt
@@ -378,6 +378,33 @@ class InntektsmeldingRoutingTest : ApiTest() {
         val fraLoepenr: Long? = null,
     )
 
+    @Test
+    fun `gir 400 Bad Request med SERIALISERINGSFEIL for ugyldige request bodies på inntektsmeldinger filter`() {
+        val tilfeller =
+            listOf(
+                """{}""",
+                """{"a": "123"}""",
+                """ikke json i det hele tatt""",
+            )
+
+        runBlocking {
+            tilfeller.forEach { body ->
+                val respons =
+                    client.post("/v1/inntektsmeldinger") {
+                        contentType(ContentType.Application.Json)
+                        setBody(body)
+                        bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
+                    }
+                val feilrespons = respons.body<ErrorResponse>()
+
+                withClue("Body: $body") {
+                    respons.status shouldBe HttpStatusCode.BadRequest
+                    feilrespons.feilkode shouldBe Feil.SERIALISERINGSFEIL.name
+                }
+            }
+        }
+    }
+
     @Serializable
     data class InntektsmeldingFilterSomTillaterLoepenrOverMaxLong(
         val orgnr: String? = null,

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRoutingTest.kt
@@ -21,18 +21,22 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.authorization.ApiTest
 import no.nav.helsearbeidsgiver.config.MAX_ANTALL_I_RESPONS
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.innsending.InnsendingStatus
 import no.nav.helsearbeidsgiver.innsending.Valideringsfeil
 import no.nav.helsearbeidsgiver.plugins.ErrorResponse
 import no.nav.helsearbeidsgiver.plugins.Feil
 import no.nav.helsearbeidsgiver.utils.DEFAULT_ORG
 import no.nav.helsearbeidsgiver.utils.buildInntektsmelding
+import no.nav.helsearbeidsgiver.utils.buildInntektsmeldingJson
 import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.mockAvvistInntektsmeldingResponse
+import no.nav.helsearbeidsgiver.utils.mockInntektsmeldingRequest
 import no.nav.helsearbeidsgiver.utils.mockInntektsmeldingResponse
+import no.nav.helsearbeidsgiver.utils.mockSkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
@@ -425,6 +429,8 @@ class InntektsmeldingRoutingTest : ApiTest() {
                     "Illegal input: Unexpected JSON token at offset 23: Unexpected 'null' value instead of string literal at path: \$.navReferanseId",
                 """{"navReferanseId": {}}""" to
                     "Illegal input: Unexpected JSON token at offset 19: Expected beginning of the string, but got { at path: \$.navReferanseId",
+                mockInntektsmeldingRequest().toJson(InntektsmeldingRequest.serializer()).toString().replace("BEDRIFTSBARNEHAGEPLASS", "") to
+                    "Illegal input: Naturalytelse.Kode does not contain element with name '' at path \$.naturalytelser[0].naturalytelse",
             )
 
         runBlocking {
@@ -439,8 +445,8 @@ class InntektsmeldingRoutingTest : ApiTest() {
 
                 withClue("Body: $body") {
                     respons.status shouldBe HttpStatusCode.BadRequest
-                    feilrespons.feilkode shouldBe Feil.SERIALISERINGSFEIL.name
                     feilrespons.feilmelding shouldBe feilmeldingInneholder
+                    feilrespons.feilkode shouldBe Feil.SERIALISERINGSFEIL.name
                 }
             }
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRoutingTest.kt
@@ -2,6 +2,7 @@
 
 package no.nav.helsearbeidsgiver.soeknad
 
+import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
 import io.ktor.client.request.bearerAuth
@@ -22,6 +23,8 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.authorization.ApiTest
+import no.nav.helsearbeidsgiver.plugins.ErrorResponse
+import no.nav.helsearbeidsgiver.plugins.Feil
 import no.nav.helsearbeidsgiver.utils.DEFAULT_ORG
 import no.nav.helsearbeidsgiver.utils.TIGERSYS_ORGNR
 import no.nav.helsearbeidsgiver.utils.TestData
@@ -294,6 +297,33 @@ class SoeknadRoutingTest : ApiTest() {
                     bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
                 }
             response.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
+    @Test
+    fun `gir 400 Bad Request med SERIALISERINGSFEIL for ugyldige request bodies på sykepengesoeknader filter`() {
+        val tilfeller =
+            listOf(
+                """{}""",
+                """{"a": "123"}""",
+                """ikke json i det hele tatt""",
+            )
+
+        runBlocking {
+            tilfeller.forEach { body ->
+                val respons =
+                    client.post("/v1/sykepengesoeknader") {
+                        contentType(ContentType.Application.Json)
+                        setBody(body)
+                        bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
+                    }
+                val feilrespons = respons.body<ErrorResponse>()
+
+                withClue("Body: $body") {
+                    respons.status shouldBe HttpStatusCode.BadRequest
+                    feilrespons.feilkode shouldBe Feil.SERIALISERINGSFEIL.name
+                }
+            }
         }
     }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
@@ -27,6 +27,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.authorization.ApiTest
 import no.nav.helsearbeidsgiver.config.MAX_ANTALL_I_RESPONS
+import no.nav.helsearbeidsgiver.plugins.ErrorResponse
+import no.nav.helsearbeidsgiver.plugins.Feil
 import no.nav.helsearbeidsgiver.sykmelding.SykmeldingStatusKafkaEventDTO.ArbeidsgiverStatusDTO
 import no.nav.helsearbeidsgiver.sykmelding.model.Sykmelding
 import no.nav.helsearbeidsgiver.utils.DEFAULT_FNR
@@ -38,6 +40,8 @@ import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
 import no.nav.helsearbeidsgiver.utils.gyldigTokenxToken
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -47,10 +51,6 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.random.Random
-import no.nav.helsearbeidsgiver.plugins.ErrorResponse
-import no.nav.helsearbeidsgiver.plugins.Feil
-import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
-import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 
 class SykmeldingRoutingTest : ApiTest() {
     @BeforeEach
@@ -403,46 +403,46 @@ class SykmeldingRoutingTest : ApiTest() {
 
     @Test
     fun `gir 400 Bad Request med SERIALISERINGSFEIL for ugyldige request bodies`() {
-        data class Case(
-            val body: String?,
-            val feilmeldingInneholder: String,
-        )
-
-        val cases =
+        val orgnr = Orgnr.genererGyldig()
+        val tilfeller =
             listOf(
-                Case("""ikke json i det hele tatt""", "Illegal input: Unexpected JSON token at offset 0: Expected start of the object '{', but had 'i' instead at path: \$"),
-                Case("""{"orgnr": {}}""", "Illegal input: Unexpected JSON token at offset 10: Expected beginning of the string, but got { at path: \$.orgnr"),
-                Case("""{"a": "123"}""", "Illegal input: Encountered an unknown key 'a' at offset 2 at path: \$"),
-                Case("""{}""", "Illegal input: Field 'orgnr' is required, but it was missing at path: \$"),
-                Case("""{"orgnr": "123456789", "fom": "ikke-dato"}""", "Illegal input: Text 'ikke-dato' could not be parsed at index 0"),
-                Case("""{"orgnr": 123}""", "Illegal input: ikke et gyldig orgnr"),
-                //Case("""{"orgnr": null}""", "TODO: null for non-nullable field"), DUPLICATE: //Unexpected JSON token at offset 14: Unexpected 'null' value instead of string literal at path: $.orgnr
-                //Case("""{"orgnr": "123", "fraLoepenr": "ikke-tall"}""", "TODO: string instead of Long"), KEEP: Illegal input: Unexpected JSON token at offset 31: Unexpected symbol 'i' in numeric literal at path: $.fraLoepenr
-                //Case("""{"orgnr": "123", "fraLoepenr": 1.5}""", "TODO: float instead of Long"),
-                Case("""{"orgnr": "240520834", "fnr": true}""", "TODO: boolean instead of string"),
-                Case("""{"orgnr": "123", "fom": "2024-13-01"}""", "Illegal input: Text '2024-13-01' could not be parsed: Invalid value for MonthOfYear (valid values 1 - 12): 13"),
-                Case("""{"orgnr": "123", "fom": ""}""", "Illegal input: Text '' could not be parsed at index 0"), // Aksepterer
-                //Case("""[{"orgnr": "123"}]""", "TODO: array instead of object"), //samme som annen
-                //Case(null, "TODO: null/empty body"),
-               // Case("""{"orgnr": "123", "fraLoepenr": 9999999999999999999}""", "TODO: Long overflow"), boring
+                """{}""" to
+                    "Illegal input: Field 'orgnr' is required, but it was missing at path: \$",
+                """{"a": "123"}""" to
+                    "Illegal input: Encountered an unknown key 'a' at offset 2 at path: \$",
+                """{"orgnr": 123}""" to
+                    "Illegal input: ikke et gyldig orgnr",
+                """{"orgnr": "123", "fom": ""}""" to
+                    "Illegal input: Text '' could not be parsed at index 0",
+                """{"orgnr": $orgnr, "fom": "ikke-dato"}""" to
+                    "Illegal input: Text 'ikke-dato' could not be parsed at index 0",
+                """ikke json i det hele tatt""" to
+                    "Illegal input: Unexpected JSON token at offset 0: Expected start of the object '{', but had 'i' instead at path: \$",
+                """{"orgnr": {}}""" to
+                    "Illegal input: Unexpected JSON token at offset 10: Expected beginning of the string, but got { at path: \$.orgnr",
+                """{"orgnr": null}""" to
+                    "Illegal input: Unexpected JSON token at offset 14: Unexpected 'null' value instead of string literal at path: $.orgnr",
+                """{"orgnr": "123", "fom": "2024-13-01"}""" to
+                    "Illegal input: Text '2024-13-01' could not be parsed: Invalid value for MonthOfYear (valid values 1 - 12): 13",
+                """{"orgnr": "123", "fraLoepenr": 1.5}""" to
+                    "Illegal input: Unexpected JSON token at offset 31: Unexpected symbol '.' in numeric literal at path: \$.fraLoepenr",
+                // """{"orgnr": "240520834", "fnr": true}""" to "?", // json boolean blir parset som string, gir ikke feil
             )
 
-//        ${Orgnr.genererGyldig()}
-
         runBlocking {
-            cases.forEach { case ->
-                val response =
+            tilfeller.forEach { (body, feilmeldingInneholder) ->
+                val respons =
                     client.post("/v1/sykmeldinger") {
                         contentType(ContentType.Application.Json)
-                        setBody(case.body)
+                        setBody(body)
                         bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
                     }
-                val errorResponse = response.body<ErrorResponse>()
+                val feilrespons = respons.body<ErrorResponse>()
 
-                withClue("Body: ${case.body}") {
-                    response.status shouldBe HttpStatusCode.BadRequest
-                    errorResponse.feilkode shouldBe Feil.SERIALISERINGSFEIL.name
-                    errorResponse.feilmelding shouldBe case.feilmeldingInneholder
+                withClue("Body: $body") {
+                    respons.status shouldBe HttpStatusCode.BadRequest
+                    feilrespons.feilkode shouldBe Feil.SERIALISERINGSFEIL.name
+                    feilrespons.feilmelding shouldBe feilmeldingInneholder
                 }
             }
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
@@ -2,7 +2,9 @@
 
 package no.nav.helsearbeidsgiver.sykmelding
 
+import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.client.call.body
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
@@ -45,6 +47,10 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.random.Random
+import no.nav.helsearbeidsgiver.plugins.ErrorResponse
+import no.nav.helsearbeidsgiver.plugins.Feil
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 
 class SykmeldingRoutingTest : ApiTest() {
     @BeforeEach
@@ -392,6 +398,53 @@ class SykmeldingRoutingTest : ApiTest() {
                     bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
                 }
             response.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
+    @Test
+    fun `gir 400 Bad Request med SERIALISERINGSFEIL for ugyldige request bodies`() {
+        data class Case(
+            val body: String?,
+            val feilmeldingInneholder: String,
+        )
+
+        val cases =
+            listOf(
+                Case("""ikke json i det hele tatt""", "Illegal input: Unexpected JSON token at offset 0: Expected start of the object '{', but had 'i' instead at path: \$"),
+                Case("""{"orgnr": {}}""", "Illegal input: Unexpected JSON token at offset 10: Expected beginning of the string, but got { at path: \$.orgnr"),
+                Case("""{"a": "123"}""", "Illegal input: Encountered an unknown key 'a' at offset 2 at path: \$"),
+                Case("""{}""", "Illegal input: Field 'orgnr' is required, but it was missing at path: \$"),
+                Case("""{"orgnr": "123456789", "fom": "ikke-dato"}""", "Illegal input: Text 'ikke-dato' could not be parsed at index 0"),
+                Case("""{"orgnr": 123}""", "Illegal input: ikke et gyldig orgnr"),
+                //Case("""{"orgnr": null}""", "TODO: null for non-nullable field"), DUPLICATE: //Unexpected JSON token at offset 14: Unexpected 'null' value instead of string literal at path: $.orgnr
+                //Case("""{"orgnr": "123", "fraLoepenr": "ikke-tall"}""", "TODO: string instead of Long"), KEEP: Illegal input: Unexpected JSON token at offset 31: Unexpected symbol 'i' in numeric literal at path: $.fraLoepenr
+                //Case("""{"orgnr": "123", "fraLoepenr": 1.5}""", "TODO: float instead of Long"),
+                Case("""{"orgnr": "240520834", "fnr": true}""", "TODO: boolean instead of string"),
+                Case("""{"orgnr": "123", "fom": "2024-13-01"}""", "Illegal input: Text '2024-13-01' could not be parsed: Invalid value for MonthOfYear (valid values 1 - 12): 13"),
+                Case("""{"orgnr": "123", "fom": ""}""", "Illegal input: Text '' could not be parsed at index 0"), // Aksepterer
+                //Case("""[{"orgnr": "123"}]""", "TODO: array instead of object"), //samme som annen
+                //Case(null, "TODO: null/empty body"),
+               // Case("""{"orgnr": "123", "fraLoepenr": 9999999999999999999}""", "TODO: Long overflow"), boring
+            )
+
+//        ${Orgnr.genererGyldig()}
+
+        runBlocking {
+            cases.forEach { case ->
+                val response =
+                    client.post("/v1/sykmeldinger") {
+                        contentType(ContentType.Application.Json)
+                        setBody(case.body)
+                        bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
+                    }
+                val errorResponse = response.body<ErrorResponse>()
+
+                withClue("Body: ${case.body}") {
+                    response.status shouldBe HttpStatusCode.BadRequest
+                    errorResponse.feilkode shouldBe Feil.SERIALISERINGSFEIL.name
+                    errorResponse.feilmelding shouldBe case.feilmeldingInneholder
+                }
+            }
         }
     }
 


### PR DESCRIPTION
**Problem:**  
Dagens løsning beskriver ikke teknisk hva som gikk galt når man sender POST til våre API og det er noe galt med JSON body som man sender inn.

**Løsning:**
Hjelpefunksjon `serialiseringsErrorResponse()` som henter ut begrunnelsen på hva som gikk galt returnerer som ErrorResponse

Eksempel:
```json
{
  "feilkode": "SERIALISERINGSFEIL",
  "feilmelding": "Illegal input: Encountered an unknown key 'orgr' at offset 5 at path: $",
  "referanseId": null
}
```

**Notater:**
Ønsker ikke at vi skal eksponere private detaljer / stack trace i feilmeldinger.  
Unngår dette ved å hente første linje av feilmelding, returnere de 300 første karakterer og bare tillatte spesifiserte feiler via regex.

Kan vurdere at tillatteRegex er overkill og fjerne det for å unngå bugs i fremtiden.

