### PR TITLE
innsending til simba med eksponert fsp

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
@@ -18,6 +18,7 @@ import no.nav.helsearbeidsgiver.auth.getSystembrukerOrgnr
 import no.nav.helsearbeidsgiver.auth.harTilgangTilRessurs
 import no.nav.helsearbeidsgiver.auth.tokenValidationContext
 import no.nav.helsearbeidsgiver.config.Services
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding.Type
 import no.nav.helsearbeidsgiver.innsending.InnsendingStatus
 import no.nav.helsearbeidsgiver.metrikk.MetrikkDokumentType
 import no.nav.helsearbeidsgiver.metrikk.tellApiRequest
@@ -145,8 +146,15 @@ private fun Route.sendInntektsmelding(
             val eksponertForespoerselId =
                 services.forespoerselService.hentEksponertForespoerselId(request.navReferanseId)
 
+            // OBS: Lager innsending med Type.Forespurt med eksponertForespørselID, slik at denne plukkes opp korrekt i Simba!
+            // Dette betyr at inntektsmelding.navReferanseId ikke alltid er lik Innsending.type.id !!!!
             val innsending =
-                request.tilInnsending(inntektsmelding.id, eksponertForespoerselId, inntektsmelding.type, VERSJON_1)
+                request.tilInnsending(
+                    inntektsmelding.id,
+                    eksponertForespoerselId,
+                    Type.Forespurt(eksponertForespoerselId, forespoersel.arbeidsgiverperiodePaakrevd),
+                    VERSJON_1,
+                )
 
             if (
                 sisteInntektsmelding != null &&

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
@@ -19,6 +19,7 @@ import no.nav.helsearbeidsgiver.auth.harTilgangTilRessurs
 import no.nav.helsearbeidsgiver.auth.tokenValidationContext
 import no.nav.helsearbeidsgiver.config.Services
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding.Type
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.AvsenderSystem
 import no.nav.helsearbeidsgiver.innsending.InnsendingStatus
 import no.nav.helsearbeidsgiver.metrikk.MetrikkDokumentType
 import no.nav.helsearbeidsgiver.metrikk.tellApiRequest
@@ -147,14 +148,22 @@ private fun Route.sendInntektsmelding(
             val eksponertForespoerselId =
                 services.forespoerselService.hentEksponertForespoerselId(request.navReferanseId)
 
-            // OBS: Lager innsending med Type.Forespurt med eksponertForespørselID, slik at denne plukkes opp korrekt i Simba!
+            // OBS: Lager innsending med Type.ForespurtEkstern med eksponertForespørselID, slik at denne plukkes opp korrekt i Simba!
             // Dette betyr at inntektsmelding.navReferanseId ikke alltid er lik Innsending.type.id !!!!
             val innsending =
                 request.tilInnsending(
                     inntektsmelding.id,
                     eksponertForespoerselId,
-                    Type.Forespurt(eksponertForespoerselId, forespoersel.arbeidsgiverperiodePaakrevd),
-                    VERSJON_1,
+                    Type.ForespurtEkstern(
+                        eksponertForespoerselId,
+                        forespoersel.arbeidsgiverperiodePaakrevd,
+                        AvsenderSystem(
+                            Orgnr(lpsOrgnr),
+                            request.avsender.systemNavn,
+                            request.avsender.systemVersjon,
+                        ),
+                    ),
+                    versjon = VERSJON_1,
                 )
 
             if (

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
@@ -19,7 +19,6 @@ import no.nav.helsearbeidsgiver.auth.harTilgangTilRessurs
 import no.nav.helsearbeidsgiver.auth.tokenValidationContext
 import no.nav.helsearbeidsgiver.config.Services
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding.Type
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.AvsenderSystem
 import no.nav.helsearbeidsgiver.innsending.InnsendingStatus
 import no.nav.helsearbeidsgiver.metrikk.MetrikkDokumentType
 import no.nav.helsearbeidsgiver.metrikk.tellApiRequest
@@ -154,15 +153,7 @@ private fun Route.sendInntektsmelding(
                 request.tilInnsending(
                     inntektsmelding.id,
                     eksponertForespoerselId,
-                    Type.ForespurtEkstern(
-                        eksponertForespoerselId,
-                        forespoersel.arbeidsgiverperiodePaakrevd,
-                        AvsenderSystem(
-                            Orgnr(lpsOrgnr),
-                            request.avsender.systemNavn,
-                            request.avsender.systemVersjon,
-                        ),
-                    ),
+                    (inntektsmelding.type as Type.ForespurtEkstern).copy(id = eksponertForespoerselId),
                     versjon = VERSJON_1,
                 )
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/InntektsmeldingTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/InntektsmeldingTolker.kt
@@ -28,7 +28,8 @@ class InntektsmeldingTolker(
             }
         transaction {
             try {
-                if (innsendtFraNavPortal(obj.inntektsmelding.type)) { // TODO: flytt denne sjekken inn i Service - kan evt bare matche på innsendingID i basen???
+                if (innsendtFraNavPortal(obj.inntektsmelding.type)) {
+                    // TODO ^: flytt denne sjekken inn i Service - kan evt bare matche på innsendingID i basen???
                     sikkerLogger.info("Mottok im sendt fra NAV PORTAL - lagrer")
                     services.inntektsmeldingService.opprettInntektsmelding(obj.inntektsmelding)
                 } else {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/InntektsmeldingTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/inntektsmelding/InntektsmeldingTolker.kt
@@ -28,7 +28,7 @@ class InntektsmeldingTolker(
             }
         transaction {
             try {
-                if (innsendtFraNavPortal(obj.inntektsmelding.type)) { // TODO: flytt denne sjekken inn i Service
+                if (innsendtFraNavPortal(obj.inntektsmelding.type)) { // TODO: flytt denne sjekken inn i Service - kan evt bare matche på innsendingID i basen???
                     sikkerLogger.info("Mottok im sendt fra NAV PORTAL - lagrer")
                     services.inntektsmeldingService.opprettInntektsmelding(obj.inntektsmelding)
                 } else {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingAuthTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingAuthTest.kt
@@ -168,6 +168,8 @@ class InnsendingAuthTest : ApiTest() {
         } returns forespoersel
 
         every { repositories.forespoerselRepository.hentVedtaksperiodeId(forespoersel.navReferanseId) } returns UUID.randomUUID()
+        every { repositories.forespoerselRepository.hentEksponertForespoerselId(forespoersel.navReferanseId) } returns
+            forespoersel.navReferanseId
         every { repositories.inntektsmeldingRepository.hent(forespoersel.navReferanseId) } returns emptyList()
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingRouteTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingRouteTest.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.test.runTest
 import no.nav.helsearbeidsgiver.authorization.ApiTest
 import no.nav.helsearbeidsgiver.config.Services
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.AvsenderSystem
 import no.nav.helsearbeidsgiver.forespoersel.Status
 import no.nav.helsearbeidsgiver.inntektsmelding.InntektsmeldingArbeidsgiver
 import no.nav.helsearbeidsgiver.inntektsmelding.InntektsmeldingRequest
@@ -26,6 +28,7 @@ import no.nav.helsearbeidsgiver.plugins.ErrorResponse
 import no.nav.helsearbeidsgiver.plugins.Feil
 import no.nav.helsearbeidsgiver.plugins.FeilMedReferanse
 import no.nav.helsearbeidsgiver.utils.DEFAULT_ORG
+import no.nav.helsearbeidsgiver.utils.TIGERSYS_ORGNR
 import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.mockForespoersel
@@ -61,10 +64,16 @@ class InnsendingRouteTest : ApiTest() {
             every { repositories.inntektsmeldingRepository.hent(forespoersel.navReferanseId) } returns emptyList()
             val response = sendInnInntektsmelding(requestBody)
             response.status shouldBe HttpStatusCode.Created
+            val innsendingTypeMedEksponertForespoerselId =
+                Inntektsmelding.Type.ForespurtEkstern(
+                    eksponertForespoerselId,
+                    forespoersel.arbeidsgiverperiodePaakrevd,
+                    AvsenderSystem(TIGERSYS_ORGNR, requestBody.avsender.systemNavn, requestBody.avsender.systemVersjon),
+                )
             verify(exactly = 1) {
                 services.opprettImTransaction(
                     match { it.type.id == requestBody.navReferanseId },
-                    match { it.type.id == eksponertForespoerselId },
+                    match { it.type == innsendingTypeMedEksponertForespoerselId },
                 )
             }
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingRouteTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingRouteTest.kt
@@ -52,16 +52,19 @@ class InnsendingRouteTest : ApiTest() {
         runTest {
             val requestBody = InnsendingMockData.requestBody
             val forespoersel = InnsendingMockData.forespoersel
+            val eksponertForespoerselId = UUID.randomUUID()
             every { repositories.forespoerselRepository.hentForespoersel(forespoersel.navReferanseId) } returns
                 forespoersel
             every { repositories.forespoerselRepository.hentVedtaksperiodeId(forespoersel.navReferanseId) } returns UUID.randomUUID()
+            every { repositories.forespoerselRepository.hentEksponertForespoerselId(forespoersel.navReferanseId) } returns
+                eksponertForespoerselId
             every { repositories.inntektsmeldingRepository.hent(forespoersel.navReferanseId) } returns emptyList()
             val response = sendInnInntektsmelding(requestBody)
             response.status shouldBe HttpStatusCode.Created
             verify(exactly = 1) {
                 services.opprettImTransaction(
                     match { it.type.id == requestBody.navReferanseId },
-                    match { it.type.id == requestBody.navReferanseId },
+                    match { it.type.id == eksponertForespoerselId },
                 )
             }
         }
@@ -179,6 +182,8 @@ class InnsendingRouteTest : ApiTest() {
             val requestBody = InnsendingMockData.requestBody.copy(aarsakInnsending = AarsakInnsending.Endring, inntekt = endretInntekt)
             val forespoersel = InnsendingMockData.forespoersel.copy(status = Status.BESVART)
             every { repositories.forespoerselRepository.hentForespoersel(forespoersel.navReferanseId) } returns forespoersel
+            every { repositories.forespoerselRepository.hentEksponertForespoerselId(forespoersel.navReferanseId) } returns
+                forespoersel.navReferanseId
             every { repositories.forespoerselRepository.hentVedtaksperiodeId(forespoersel.navReferanseId) } returns UUID.randomUUID()
             every { repositories.inntektsmeldingRepository.hent(forespoersel.navReferanseId) } returns
                 listOf(


### PR DESCRIPTION
Inntektsmeldinger i API sendes inn på AKTIV forespørsel. 
Men Simba baserer seg på eksponert forespørselId når den slår opp inntektsmelding som skal distribueres ut etter journalføring. 

Det blir krøll når vi har lagret journalpostID og deretter forsøker å hente ut nyeste IM for ikke-eksponert forespørselID (siden den ikke finnes).
Vi får da den smått forvirrende loggmeldingen:
Inntektsmelding journalført, men ikke distribuert pga. nyere innsending.

Ingenting distribueres, og innsendingen blir stuck i MOTTATT. 

Denne PR endrer Innsending-objektet som opprettes i InnsendingRoute og sendes til Simba.
Setter eksponert forespørselID istedenfor faktisk (aktiv) forespørselId 
- da vil SImba prosessere disse korrekt og likt som IM sendt inn fra Simba-frontend. 
Beholder fortsatt aktiv forespørselID i Inntektsmelding-kvittering som vises til bruker i API - for å ikke forvirre API-brukere, det vil være merkelig om det plutselig blir satt en ny forespørselID i kvitteringen.
