### PR TITLE
Legg til tokenX endepunkt for søknad PDF (for bruk fra arbeidsflaten Altinn)

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/Routing.kt
@@ -13,6 +13,7 @@ import no.nav.helsearbeidsgiver.forespoersel.forespoerselV1
 import no.nav.helsearbeidsgiver.helsesjekker.naisRoutes
 import no.nav.helsearbeidsgiver.inntektsmelding.inntektsmeldingV1
 import no.nav.helsearbeidsgiver.metrikk.metrikkRoutes
+import no.nav.helsearbeidsgiver.soeknad.soeknadTokenX
 import no.nav.helsearbeidsgiver.soeknad.soeknadV1
 import no.nav.helsearbeidsgiver.sykmelding.sykmeldingTokenX
 import no.nav.helsearbeidsgiver.sykmelding.sykmeldingV1
@@ -39,7 +40,8 @@ fun Application.configureRouting(
             soeknadV1(soeknadService = services.soeknadService, unleashFeatureToggles)
         }
         authenticate("tokenx-config") {
-            sykmeldingTokenX(sykmeldingService = services.sykmeldingService, unleashFeatureToggles)
+            sykmeldingTokenX(sykmeldingService = services.sykmeldingService)
+            soeknadTokenX(soeknadService = services.soeknadService)
         }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
@@ -12,8 +12,10 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.helsearbeidsgiver.Env
 import no.nav.helsearbeidsgiver.auth.getConsumerOrgnr
+import no.nav.helsearbeidsgiver.auth.getPidFromTokenX
 import no.nav.helsearbeidsgiver.auth.getSystembrukerOrgnr
 import no.nav.helsearbeidsgiver.auth.harTilgangTilRessurs
+import no.nav.helsearbeidsgiver.auth.personHarTilgangTilRessurs
 import no.nav.helsearbeidsgiver.auth.tokenValidationContext
 import no.nav.helsearbeidsgiver.metrikk.MetrikkDokumentType
 import no.nav.helsearbeidsgiver.metrikk.tellApiRequest
@@ -158,6 +160,54 @@ private fun Route.filtrerSoeknader(
         } catch (e: Exception) {
             sikkerLogger().error(Feil.FEIL_VED_HENTING_SYKEPENGESOEKNADER.feilmelding, e)
             call.respond(HttpStatusCode.InternalServerError, ErrorResponse(Feil.FEIL_VED_HENTING_SYKEPENGESOEKNADER))
+        }
+    }
+}
+
+fun Route.soeknadTokenX(soeknadService: SoeknadService) {
+    route("/intern/personbruker") {
+        get("/sykepengesoeknad/{soeknadId}/pdf") {
+            try {
+                val tokenContext = tokenValidationContext()
+                val pid = tokenContext.getPidFromTokenX()
+
+                if (pid == null) {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(Feil.MANGLER_BRUKERIDENTIFIKASJON))
+                    return@get
+                }
+
+                val soeknadId = call.parameters["soeknadId"]?.toUuidOrNull()
+                if (soeknadId == null) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_SOEKNAD_ID))
+                    return@get
+                }
+
+                val soeknad = soeknadService.hentSoeknad(soeknadId)
+                if (soeknad == null) {
+                    call.respond(HttpStatusCode.NotFound, ErrorResponse(FeilMedReferanse.SOEKNAD_IKKE_FUNNET, soeknadId))
+                    return@get
+                }
+
+                if (!tokenContext.personHarTilgangTilRessurs(
+                        ressurs = SOEKNAD_RESSURS,
+                        orgnr = soeknad.arbeidsgiver.orgnr,
+                        pid = pid,
+                    )
+                ) {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(Feil.IKKE_TILGANG_TIL_RESSURS))
+                    return@get
+                }
+
+                sikkerLogger().info("Bruker med PID: $pid henter sykepengesoeknad PDF: $soeknadId")
+
+                val soeknadForPDF = soeknadService.tilSoeknadForPdf(soeknad)
+                val pdfBytes = genererSoeknadPdf(soeknadForPDF)
+                call.respondMedPDF(bytes = pdfBytes, filnavn = "sykepengesoeknad-${soeknad.soeknadId}.pdf")
+            } catch (e: Exception) {
+                logger().error(Feil.FEIL_VED_HENTING_SYKEPENGESOEKNAD.feilmelding)
+                sikkerLogger().error(Feil.FEIL_VED_HENTING_SYKEPENGESOEKNAD.feilmelding, e)
+                call.respond(HttpStatusCode.InternalServerError, ErrorResponse(Feil.FEIL_VED_HENTING_SYKEPENGESOEKNAD))
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
@@ -166,7 +166,7 @@ private fun Route.filtrerSoeknader(
 
 fun Route.soeknadTokenX(soeknadService: SoeknadService) {
     route("/intern/personbruker") {
-        get("/sykepengesoeknad/{soknad}/pdf") {
+        get("/soknad/{soknadId}/pdf") {
             try {
                 val tokenContext = tokenValidationContext()
                 val pid = tokenContext.getPidFromTokenX()
@@ -176,7 +176,7 @@ fun Route.soeknadTokenX(soeknadService: SoeknadService) {
                     return@get
                 }
 
-                val soeknadId = call.parameters["soknad"]?.toUuidOrNull()
+                val soeknadId = call.parameters["soknadId"]?.toUuidOrNull()
                 if (soeknadId == null) {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_SOEKNAD_ID))
                     return@get

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
@@ -166,7 +166,7 @@ private fun Route.filtrerSoeknader(
 
 fun Route.soeknadTokenX(soeknadService: SoeknadService) {
     route("/intern/personbruker") {
-        get("/soknad/{soknadId}/pdf") {
+        get("/sykepengesoeknad/{soknadId}/pdf") {
             try {
                 val tokenContext = tokenValidationContext()
                 val pid = tokenContext.getPidFromTokenX()

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRouting.kt
@@ -166,7 +166,7 @@ private fun Route.filtrerSoeknader(
 
 fun Route.soeknadTokenX(soeknadService: SoeknadService) {
     route("/intern/personbruker") {
-        get("/sykepengesoeknad/{soeknadId}/pdf") {
+        get("/sykepengesoeknad/{soknad}/pdf") {
             try {
                 val tokenContext = tokenValidationContext()
                 val pid = tokenContext.getPidFromTokenX()
@@ -176,7 +176,7 @@ fun Route.soeknadTokenX(soeknadService: SoeknadService) {
                     return@get
                 }
 
-                val soeknadId = call.parameters["soeknadId"]?.toUuidOrNull()
+                val soeknadId = call.parameters["soknad"]?.toUuidOrNull()
                 if (soeknadId == null) {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(Feil.UGYLDIG_SOEKNAD_ID))
                     return@get

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRouting.kt
@@ -182,17 +182,10 @@ private fun Route.filtrerSykmeldinger(
     }
 }
 
-fun Route.sykmeldingTokenX(
-    sykmeldingService: SykmeldingService,
-    unleashFeatureToggles: UnleashFeatureToggles,
-) {
+fun Route.sykmeldingTokenX(sykmeldingService: SykmeldingService) {
     route("/intern/personbruker") {
         get("/sykmelding/{sykmeldingId}/pdf") {
             try {
-                if (!unleashFeatureToggles.skalEksponereSykmeldingerPDF()) {
-                    call.respond(HttpStatusCode.Forbidden)
-                    return@get
-                }
                 val tokenContext = tokenValidationContext()
                 val pid = tokenContext.getPidFromTokenX()
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRouting.kt
@@ -74,9 +74,7 @@ private fun Route.sykmelding(
     }
     get("/sykmelding/{sykmeldingId}/pdf") {
         val lpsOrgnr = tokenValidationContext().getConsumerOrgnr()
-        if (!unleashFeatureToggles.skalEksponereSykmeldinger(Orgnr(lpsOrgnr)) ||
-            !unleashFeatureToggles.skalEksponereSykmeldingerPDF()
-        ) {
+        if (!unleashFeatureToggles.skalEksponereSykmeldinger(Orgnr(lpsOrgnr))) {
             call.respond(HttpStatusCode.Forbidden)
             return@get
         }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/UnleashFeatureToggles.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/UnleashFeatureToggles.kt
@@ -106,12 +106,6 @@ class UnleashFeatureToggles(
             false,
         )
 
-    fun skalEksponereSykmeldingerPDF(): Boolean =
-        unleashClient.isEnabled(
-            "eksponer-sykmelding-PDF-i-api",
-            false,
-        )
-
     fun skalKonsumereStatusISpeil(): Boolean =
         unleashClient.isEnabled(
             "konsumer-status-i-speil",

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/authorization/HentApiAuthTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/authorization/HentApiAuthTest.kt
@@ -48,7 +48,6 @@ abstract class HentApiAuthTest<Dokument, Filter, DokumentDTO> : ApiTest() {
         every { unleashFeatureToggles.skalEksponereForespoersler() } returns true
         every { unleashFeatureToggles.skalEksponereInntektsmeldinger() } returns true
         every { unleashFeatureToggles.skalEksponereSykmeldinger(TIGERSYS_ORGNR) } returns true
-        every { unleashFeatureToggles.skalEksponereSykmeldingerPDF() } returns true
     }
 
     @AfterAll

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadTokenXRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadTokenXRoutingTest.kt
@@ -1,0 +1,106 @@
+package no.nav.helsearbeidsgiver.soeknad
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.runBlocking
+import no.nav.helsearbeidsgiver.authorization.ApiTest
+import no.nav.helsearbeidsgiver.utils.DEFAULT_FNR
+import no.nav.helsearbeidsgiver.utils.DEFAULT_ORG
+import no.nav.helsearbeidsgiver.utils.TestData.medId
+import no.nav.helsearbeidsgiver.utils.TestData.medOrgnr
+import no.nav.helsearbeidsgiver.utils.TestData.soeknadMock
+import no.nav.helsearbeidsgiver.utils.genererSoeknadPdf
+import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
+import no.nav.helsearbeidsgiver.utils.gyldigTokenxToken
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.random.Random
+
+class SoeknadTokenXRoutingTest : ApiTest() {
+    @AfterEach
+    fun setup() {
+        clearMocks(repositories.soeknadRepository)
+    }
+
+    @AfterAll
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `hent med TokenX person en sykepelseknad med id i PDF format`() {
+        val soeknadId = UUID.randomUUID()
+        val mockPdfBytes = "Mock PDF innhold".toByteArray()
+
+        mockkStatic("no.nav.helsearbeidsgiver.utils.PdfgenUtilsKt")
+        every { repositories.soeknadRepository.hentSoeknad(soeknadId) } returns
+            SykepengeSoeknadDto(Random.nextLong(), soeknadMock().medId(soeknadId).medOrgnr(DEFAULT_ORG))
+        every { repositories.sykmeldingRepository.hentSykmelding(any()) } returns null
+
+        coEvery { genererSoeknadPdf(any()) } returns mockPdfBytes
+
+        runBlocking {
+            val response =
+                client.get("/intern/personbruker/sykepengesoeknad/$soeknadId/pdf") {
+                    bearerAuth(mockOAuth2Server.gyldigTokenxToken(DEFAULT_FNR))
+                }
+            response.status shouldBe HttpStatusCode.OK
+            response.contentType() shouldBe ContentType.Application.Pdf
+            response.headers[HttpHeaders.ContentDisposition] shouldBe "inline; filename=\"sykepengesoeknad-$soeknadId.pdf\""
+            val pdfBytes = response.body<ByteArray>()
+            pdfBytes shouldBe mockPdfBytes
+        }
+    }
+
+    @Test
+    fun `hent med TokenX person endepunkt skal ikke funke med en maskinporten token`() {
+        val soeknadId = UUID.randomUUID()
+
+        every { repositories.soeknadRepository.hentSoeknad(soeknadId) } returns
+            SykepengeSoeknadDto(Random.nextLong(), soeknadMock().medId(soeknadId).medOrgnr(DEFAULT_ORG))
+        runBlocking {
+            val response =
+                client.get("/intern/personbruker/sykepengesoeknad/$soeknadId/pdf") {
+                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
+                }
+            response.status shouldBe HttpStatusCode.Unauthorized
+        }
+    }
+
+    @Test
+    fun `hent med TokenX person som ikke har tilgang skal ikke funke`() {
+        val soeknadId = UUID.randomUUID()
+
+        mockkStatic("no.nav.helsearbeidsgiver.config.ApplicationConfigKt")
+        every {
+            no.nav.helsearbeidsgiver.config
+                .getPdpService()
+                .personHarTilgang(fnr = DEFAULT_FNR, any(), any())
+        } returns false
+
+        every { repositories.soeknadRepository.hentSoeknad(soeknadId) } returns
+            SykepengeSoeknadDto(Random.nextLong(), soeknadMock().medId(soeknadId).medOrgnr(DEFAULT_ORG))
+        runBlocking {
+            val response =
+                client.get("/intern/personbruker/sykepengesoeknad/$soeknadId/pdf") {
+                    bearerAuth(mockOAuth2Server.gyldigTokenxToken(DEFAULT_FNR))
+                }
+            response.status shouldBe HttpStatusCode.Unauthorized
+        }
+        unmockkStatic("no.nav.helsearbeidsgiver.config.ApplicationConfigKt")
+    }
+}

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadTokenXRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadTokenXRoutingTest.kt
@@ -55,7 +55,7 @@ class SoeknadTokenXRoutingTest : ApiTest() {
 
         runBlocking {
             val response =
-                client.get("/intern/personbruker/soknad/$soeknadId/pdf") {
+                client.get("/intern/personbruker/sykepengesoeknad/$soeknadId/pdf") {
                     bearerAuth(mockOAuth2Server.gyldigTokenxToken(DEFAULT_FNR))
                 }
             response.status shouldBe HttpStatusCode.OK
@@ -74,7 +74,7 @@ class SoeknadTokenXRoutingTest : ApiTest() {
             SykepengeSoeknadDto(Random.nextLong(), soeknadMock().medId(soeknadId).medOrgnr(DEFAULT_ORG))
         runBlocking {
             val response =
-                client.get("/intern/personbruker/soknad/$soeknadId/pdf") {
+                client.get("/intern/personbruker/sykepengesoeknad/$soeknadId/pdf") {
                     bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
                 }
             response.status shouldBe HttpStatusCode.Unauthorized
@@ -96,7 +96,7 @@ class SoeknadTokenXRoutingTest : ApiTest() {
             SykepengeSoeknadDto(Random.nextLong(), soeknadMock().medId(soeknadId).medOrgnr(DEFAULT_ORG))
         runBlocking {
             val response =
-                client.get("/intern/personbruker/soknad/$soeknadId/pdf") {
+                client.get("/intern/personbruker/sykepengesoeknad/$soeknadId/pdf") {
                     bearerAuth(mockOAuth2Server.gyldigTokenxToken(DEFAULT_FNR))
                 }
             response.status shouldBe HttpStatusCode.Unauthorized

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadTokenXRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadTokenXRoutingTest.kt
@@ -55,7 +55,7 @@ class SoeknadTokenXRoutingTest : ApiTest() {
 
         runBlocking {
             val response =
-                client.get("/intern/personbruker/sykepengesoeknad/$soeknadId/pdf") {
+                client.get("/intern/personbruker/soknad/$soeknadId/pdf") {
                     bearerAuth(mockOAuth2Server.gyldigTokenxToken(DEFAULT_FNR))
                 }
             response.status shouldBe HttpStatusCode.OK
@@ -74,7 +74,7 @@ class SoeknadTokenXRoutingTest : ApiTest() {
             SykepengeSoeknadDto(Random.nextLong(), soeknadMock().medId(soeknadId).medOrgnr(DEFAULT_ORG))
         runBlocking {
             val response =
-                client.get("/intern/personbruker/sykepengesoeknad/$soeknadId/pdf") {
+                client.get("/intern/personbruker/soknad/$soeknadId/pdf") {
                     bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
                 }
             response.status shouldBe HttpStatusCode.Unauthorized

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadTokenXRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadTokenXRoutingTest.kt
@@ -96,7 +96,7 @@ class SoeknadTokenXRoutingTest : ApiTest() {
             SykepengeSoeknadDto(Random.nextLong(), soeknadMock().medId(soeknadId).medOrgnr(DEFAULT_ORG))
         runBlocking {
             val response =
-                client.get("/intern/personbruker/sykepengesoeknad/$soeknadId/pdf") {
+                client.get("/intern/personbruker/soknad/$soeknadId/pdf") {
                     bearerAuth(mockOAuth2Server.gyldigTokenxToken(DEFAULT_FNR))
                 }
             response.status shouldBe HttpStatusCode.Unauthorized

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/sykmelding/SykmeldingRoutingTest.kt
@@ -56,7 +56,6 @@ class SykmeldingRoutingTest : ApiTest() {
     @BeforeEach
     fun setup() {
         every { unleashFeatureToggles.skalEksponereSykmeldinger(TIGERSYS_ORGNR) } returns true
-        every { unleashFeatureToggles.skalEksponereSykmeldingerPDF() } returns true
     }
 
     @AfterEach
@@ -184,20 +183,6 @@ class SykmeldingRoutingTest : ApiTest() {
             response.status shouldBe HttpStatusCode.Unauthorized
         }
         unmockkStatic("no.nav.helsearbeidsgiver.config.ApplicationConfigKt")
-    }
-
-    @Test
-    fun `gir 403 Forbidden error om eksponer-sykmelding-PDF-i-api er skrudd av`() {
-        val sykmeldingId = UUID.randomUUID()
-
-        every { unleashFeatureToggles.skalEksponereSykmeldingerPDF() } returns false
-        runBlocking {
-            val response =
-                client.get("/v1/sykmelding/$sykmeldingId/pdf") {
-                    bearerAuth(mockOAuth2Server.gyldigSystembrukerAuthToken(DEFAULT_ORG))
-                }
-            response.status shouldBe HttpStatusCode.Forbidden
-        }
     }
 
     @Test


### PR DESCRIPTION
Problem:
Brukere via Altinn arbeidsflaten har ikke et endepunkt for å hente søknad PDF

**Løsning:**
Legger til ett tokenX endepunkt for søknad PDF som blir tilgjengelig via dokument proxy
Laget en [PR for dialog appen](https://github.com/navikt/hag-dialog/pull/60) som referer til dette søknad endepunktet

Sletter unleash toggle for sykmelding tokenX og legger ikke til for nye endepunktet da det er vurdert unødvendig.