### PR TITLE
Legg til behandlingsdager i søknaden

### DIFF
--- a/openApiTasks.gradle.kts
+++ b/openApiTasks.gradle.kts
@@ -172,8 +172,9 @@ tags:
                 Regex("""  /health/is-(?:alive|ready):[\s\S]*?(?=  /[^/]|$)""") to "",
                 // Fjern metrics-endepunkt
                 Regex("""  /metrics:[\s\S]*?(?=  /[^/]|$)""") to "",
-                // Fjern intern personbruker sykmelding PDF-endepunkt
+                // Fjern intern personbruker PDF-endepunkt
                 removeGroup("/intern/personbruker/sykmelding/{sykmeldingId}/pdf:"),
+                removeGroup("/intern/personbruker/sykepengesoeknad/{soknadId}/pdf:"),
                 // Fjern depricated endepunkt
                 removeGroup("/v1/sykmelding/{sykmeldingId}.pdf:"),
                 // Endre PDF format fra byte til binary

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/Sykepengesoeknad.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/Sykepengesoeknad.kt
@@ -33,7 +33,7 @@ data class Sykepengesoeknad(
     val soektUtenlandsopphold: Boolean?,
     val korrigerer: UUID?,
     val soeknadsperioder: List<Soeknadsperiode>,
-    // val behandlingsdager: List<LocalDate>,
+    val behandlingsdager: List<LocalDate>,
     val fravaer: List<Fravaer>,
 ) {
     @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/SoeknadUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/SoeknadUtils.kt
@@ -18,7 +18,7 @@ fun SykepengeSoeknadKafkaMelding.konverter(loepenr: Long): Sykepengesoeknad =
         tom = tom,
         arbeidGjenopptattDato = arbeidGjenopptatt,
         mottatTid = utledSendtTid(),
-        // behandlingsdager = behandlingsdager ?: emptyList(), TODO: skal vi ta med denne videre til ag?
+        behandlingsdager = behandlingsdager ?: emptyList(),
         fravaer = fravar?.map { it.konverter() }.orEmpty(),
         soeknadsperioder = soknadsperioder?.map { it.konverter() }.orEmpty(),
     )

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -1256,6 +1256,11 @@ components:
           type: "array"
           items:
             $ref: "#/components/schemas/Soeknadsperiode"
+        behandlingsdager:
+          type: "array"
+          items:
+            type: "string"
+            format: "date"
         fravaer:
           type: "array"
           items:
@@ -1268,6 +1273,7 @@ components:
         - "mottatTid"
         - "arbeidsgiver"
         - "soeknadsperioder"
+        - "behandlingsdager"
         - "fravaer"
     SykepengesoeknadFilter:
       type: "object"

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRoutingTest.kt
@@ -34,6 +34,7 @@ import no.nav.helsearbeidsgiver.utils.genererSoeknadPdf
 import no.nav.helsearbeidsgiver.utils.gyldigSystembrukerAuthToken
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.test.date.mai
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -43,7 +44,6 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.random.Random
-import no.nav.helsearbeidsgiver.utils.test.date.mai
 
 class SoeknadRoutingTest : ApiTest() {
     @BeforeEach

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRoutingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadRoutingTest.kt
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.random.Random
+import no.nav.helsearbeidsgiver.utils.test.date.mai
 
 class SoeknadRoutingTest : ApiTest() {
     @BeforeEach
@@ -74,6 +75,7 @@ class SoeknadRoutingTest : ApiTest() {
             val soeknadRespons = respons.body<Sykepengesoeknad>()
             soeknadRespons.arbeidsgiver.orgnr shouldBe DEFAULT_ORG
             soeknadRespons.soeknadId shouldBe soeknad.sykepengeSoeknadKafkaMelding.id
+            soeknadRespons.behandlingsdager shouldBe listOf(5.mai)
         }
     }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/TestData.kt
@@ -785,7 +785,7 @@ object TestData {
             "yrkesskade": null,
             "arbeidUtenforNorge": null,
             "harRedusertVenteperiode": null,
-            "behandlingsdager": [],
+            "behandlingsdager": ["2018-05-05"],
             "permitteringer": [],
             "merknaderFraSykmelding": null,
             "egenmeldingsdagerFraSykmelding": null,


### PR DESCRIPTION
**Problem:**
Behandlingsdager var inkludert i PDFen men ikke XML og har derfor glippet i vårt API.

**Løsning:**
Inkluder feltet i mapping fra kafka og om feltet er null sett som tom liste

Oppdatert modifyOpenAPI script til å ikke inkludere det nye interne søknad endepunktet