### PR TITLE
ikke gjør duplikatsjekk hvis forrige IM har status FEILET

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/InntektsmeldingRouting.kt
@@ -158,7 +158,7 @@ private fun Route.sendInntektsmelding(
                 )
 
             if (
-                sisteInntektsmelding != null &&
+                sisteInntektsmelding != null && sisteInntektsmelding.status != InnsendingStatus.FEILET &&
                 innsending.skjema.erDuplikat(
                     sisteInntektsmelding.tilSkjemaInntektsmelding(eksponertForespoerselId),
                 )

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingRouteTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/innsending/InnsendingRouteTest.kt
@@ -118,6 +118,28 @@ class InnsendingRouteTest : ApiTest() {
         }
 
     @Test
+    fun `innsending av duplikat inntektsmelding er tillatt hvis forrige innsendte har status FEILET`() =
+        runTest {
+            val requestBody = InnsendingMockData.requestBody.copy(aarsakInnsending = AarsakInnsending.Endring)
+            val forespoersel = InnsendingMockData.forespoersel.copy(status = Status.BESVART)
+            every { repositories.forespoerselRepository.hentForespoersel(forespoersel.navReferanseId) } returns forespoersel
+            every { repositories.forespoerselRepository.hentVedtaksperiodeId(forespoersel.navReferanseId) } returns UUID.randomUUID()
+            every { repositories.inntektsmeldingRepository.hent(forespoersel.navReferanseId) } returns
+                listOf(
+                    InnsendingMockData.imResponse.copy(status = InnsendingStatus.FEILET),
+                )
+            val response = sendInnInntektsmelding(requestBody)
+            response.status shouldBe HttpStatusCode.Created
+
+            verify(exactly = 1) {
+                services.opprettImTransaction(
+                    inntektsmelding = any(),
+                    innsending = any(),
+                )
+            }
+        }
+
+    @Test
     fun `innsending av inntektsmelding med aarsak Ny der tidligere innsending finnes gir bad request`() =
         runTest {
             val requestBody = InnsendingMockData.requestBody.copy(aarsakInnsending = AarsakInnsending.Ny)


### PR DESCRIPTION
Siden det kan f eks være feil inntekt rapportert i A-ordningen, så kan de rette opp der, og deretter sende inn samme IM på nytt..