### PR TITLE
cleanup: fjerner inbound rule for sanert app i dev

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -59,7 +59,6 @@ spec:
 
     inbound:
       rules:
-        - application: im-dokument-proxy
         - application: hag-dokument-proxy
         # TODO: Fjern om vi ikke trenger tokenx-token-generator lenger
         - application: tokenx-token-generator


### PR DESCRIPTION
im-dokument-proxy fins ikke lengre, erstattet med hag-dokument-proxy