### PR TITLE
bugfix kafka distribusjon

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/soeknad/SoeknadTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/soeknad/SoeknadTolker.kt
@@ -5,6 +5,7 @@ import no.nav.helsearbeidsgiver.soeknad.SoeknadService
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import org.jetbrains.exposed.sql.transactions.transaction
 
 class SoeknadTolker(
     private val soeknadService: SoeknadService,
@@ -13,17 +14,20 @@ class SoeknadTolker(
     private val logger = logger()
 
     override fun lesMelding(melding: String) {
-        try {
-            val soeknadMessage = melding.fromJson(SykepengeSoeknadKafkaMelding.serializer())
-            sikkerLogger.info(
-                "Mottok søknad med id ${soeknadMessage.id}, sykmeldingId ${soeknadMessage.sykmeldingId} og sendtNav ${soeknadMessage.sendtNav}.",
-            )
-            soeknadService.behandleSoeknad(soeknadMessage)
-        } catch (e: Exception) {
-            val errorMsg = "Klarte ikke å lagre søknad om sykepenger!"
-            logger.error(errorMsg)
-            sikkerLogger.error(errorMsg, e)
-            throw e
+        transaction {
+            try {
+                val soeknadMessage = melding.fromJson(SykepengeSoeknadKafkaMelding.serializer())
+                sikkerLogger.info(
+                    "Mottok søknad med id ${soeknadMessage.id}, sykmeldingId ${soeknadMessage.sykmeldingId} og sendtNav ${soeknadMessage.sendtNav}.",
+                )
+                soeknadService.behandleSoeknad(soeknadMessage)
+            } catch (e: Exception) {
+                val errorMsg = "Klarte ikke å lagre søknad om sykepenger!"
+                logger.error(errorMsg)
+                sikkerLogger.error(errorMsg, e)
+                rollback()
+                throw e
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/soeknad/SoeknadTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/soeknad/SoeknadTolker.kt
@@ -5,7 +5,6 @@ import no.nav.helsearbeidsgiver.soeknad.SoeknadService
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
-import org.jetbrains.exposed.sql.transactions.transaction
 
 class SoeknadTolker(
     private val soeknadService: SoeknadService,
@@ -14,20 +13,17 @@ class SoeknadTolker(
     private val logger = logger()
 
     override fun lesMelding(melding: String) {
-        transaction {
-            try {
-                val soeknadMessage = melding.fromJson(SykepengeSoeknadKafkaMelding.serializer())
-                sikkerLogger.info(
-                    "Mottok søknad med id ${soeknadMessage.id}, sykmeldingId ${soeknadMessage.sykmeldingId} og sendtNav ${soeknadMessage.sendtNav}.",
-                )
-                soeknadService.behandleSoeknad(soeknadMessage)
-            } catch (e: Exception) {
-                val errorMsg = "Klarte ikke å lagre søknad om sykepenger!"
-                logger.error(errorMsg)
-                sikkerLogger.error(errorMsg, e)
-                rollback()
-                throw e
-            }
+        try {
+            val soeknadMessage = melding.fromJson(SykepengeSoeknadKafkaMelding.serializer())
+            sikkerLogger.info(
+                "Mottok søknad med id ${soeknadMessage.id}, sykmeldingId ${soeknadMessage.sykmeldingId} og sendtNav ${soeknadMessage.sendtNav}.",
+            )
+            soeknadService.behandleSoeknad(soeknadMessage)
+        } catch (e: Exception) {
+            val errorMsg = "Klarte ikke å lagre søknad om sykepenger!"
+            logger.error(errorMsg)
+            sikkerLogger.error(errorMsg, e)
+            throw e
         }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/sykmelding/SykmeldingTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/sykmelding/SykmeldingTolker.kt
@@ -10,7 +10,6 @@ import no.nav.helsearbeidsgiver.utils.jsonMapper
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import no.nav.helsearbeidsgiver.utils.toUuidOrNull
-import org.jetbrains.exposed.sql.transactions.transaction
 
 class SykmeldingTolker(
     private val sykmeldingService: SykmeldingService,
@@ -21,36 +20,33 @@ class SykmeldingTolker(
     private val logger = logger()
 
     override fun lesMelding(melding: String) {
-        transaction {
-            try {
-                val sykmeldingMessage = jsonMapper.decodeFromString<SendSykmeldingAivenKafkaMessage>(melding)
-                val sykmeldingId =
-                    sykmeldingMessage.sykmelding.id.toUuidOrNull()
-                        ?: throw IllegalArgumentException("Mottatt sykmeldingId ${sykmeldingMessage.sykmelding.id} er ikke en gyldig UUID.")
+        try {
+            val sykmeldingMessage = jsonMapper.decodeFromString<SendSykmeldingAivenKafkaMessage>(melding)
+            val sykmeldingId =
+                sykmeldingMessage.sykmelding.id.toUuidOrNull()
+                    ?: throw IllegalArgumentException("Mottatt sykmeldingId ${sykmeldingMessage.sykmelding.id} er ikke en gyldig UUID.")
 
-                val fullPerson = pdlService.hentFullPerson(sykmeldingMessage.kafkaMetadata.fnr, sykmeldingId)
+            val fullPerson = pdlService.hentFullPerson(sykmeldingMessage.kafkaMetadata.fnr, sykmeldingId)
 
-                sykmeldingService.lagreSykmelding(sykmeldingMessage, sykmeldingId, fullPerson.navn.fulltNavn())
-                dokumentkoblingService.produserSykmeldingKobling(
-                    sykmeldingId = sykmeldingId,
-                    sykmeldingMessage = sykmeldingMessage,
-                    fullPerson = fullPerson,
-                )
-            } catch (e: FantIkkePersonException) {
-                logger.error("Fant ikke person i PDL, ignorerer sykmelding!")
-                sikkerLogger.error(
-                    "Fant ikke person i PDL med fnr(${e.fnr}), ignorerer sykmelding med id: ${e.sykmeldingId}!",
-                    e,
-                )
-            } catch (e: Exception) {
-                // TODO: Skille på andre exceptions fra pdl, fra db og fra kafka
-                "En feil oppstod, avbryter og forsøker igjen".also {
-                    logger.error(it)
-                    sikkerLogger.error(it, e)
-                }
-                rollback()
-                throw e // sørg for at kafka-offset ikke commites dersom vi ikke lagrer i db
+            sykmeldingService.lagreSykmelding(sykmeldingMessage, sykmeldingId, fullPerson.navn.fulltNavn())
+            dokumentkoblingService.produserSykmeldingKobling(
+                sykmeldingId = sykmeldingId,
+                sykmeldingMessage = sykmeldingMessage,
+                fullPerson = fullPerson,
+            )
+        } catch (e: FantIkkePersonException) {
+            logger.error("Fant ikke person i PDL, ignorerer sykmelding!")
+            sikkerLogger.error(
+                "Fant ikke person i PDL med fnr(${e.fnr}), ignorerer sykmelding med id: ${e.sykmeldingId}!",
+                e,
+            )
+        } catch (e: Exception) {
+            // TODO: Skille på exception fra db og kafka
+            "En feil oppstod, avbryter og forsøker igjen".also {
+                logger.error(it)
+                sikkerLogger.error(it, e)
             }
+            throw e // sørg for at kafka-offset ikke commites dersom vi ikke lagrer i db
         }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/sykmelding/SykmeldingTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/sykmelding/SykmeldingTolker.kt
@@ -27,21 +27,13 @@ class SykmeldingTolker(
                     ?: throw IllegalArgumentException("Mottatt sykmeldingId ${sykmeldingMessage.sykmelding.id} er ikke en gyldig UUID.")
 
             val fullPerson = pdlService.hentFullPerson(sykmeldingMessage.kafkaMetadata.fnr, sykmeldingId)
-            val harLagretSykmelding =
-                sykmeldingService.lagreSykmelding(sykmeldingMessage, sykmeldingId, fullPerson.navn.fulltNavn())
 
-            if (harLagretSykmelding) {
-                dokumentkoblingService.produserSykmeldingKobling(
-                    sykmeldingId = sykmeldingId,
-                    sykmeldingMessage = sykmeldingMessage,
-                    fullPerson = fullPerson,
-                )
-            } else {
-                logger
-                    .info(
-                        "Oppretter ikke dialog for sykmelding $sykmeldingId, fordi sykmeldingen ikke ble lagret.",
-                    )
-            }
+            sykmeldingService.lagreSykmelding(sykmeldingMessage, sykmeldingId, fullPerson.navn.fulltNavn())
+            dokumentkoblingService.produserSykmeldingKobling(
+                sykmeldingId = sykmeldingId,
+                sykmeldingMessage = sykmeldingMessage,
+                fullPerson = fullPerson,
+            )
         } catch (e: FantIkkePersonException) {
             logger.error("Fant ikke person i PDL, ignorerer sykmelding!")
             sikkerLogger.error(
@@ -49,7 +41,8 @@ class SykmeldingTolker(
                 e,
             )
         } catch (e: Exception) {
-            "Klarte ikke å lagre sykmelding og opprette Dialogporten-dialog!".also {
+            // TODO: Skille på exception fra db og kafka
+            "En feil oppstod, avbryter og forsøker igjen".also {
                 logger.error(it)
                 sikkerLogger.error(it, e)
             }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/sykmelding/SykmeldingTolker.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/kafka/sykmelding/SykmeldingTolker.kt
@@ -10,6 +10,7 @@ import no.nav.helsearbeidsgiver.utils.jsonMapper
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import no.nav.helsearbeidsgiver.utils.toUuidOrNull
+import org.jetbrains.exposed.sql.transactions.transaction
 
 class SykmeldingTolker(
     private val sykmeldingService: SykmeldingService,
@@ -20,33 +21,36 @@ class SykmeldingTolker(
     private val logger = logger()
 
     override fun lesMelding(melding: String) {
-        try {
-            val sykmeldingMessage = jsonMapper.decodeFromString<SendSykmeldingAivenKafkaMessage>(melding)
-            val sykmeldingId =
-                sykmeldingMessage.sykmelding.id.toUuidOrNull()
-                    ?: throw IllegalArgumentException("Mottatt sykmeldingId ${sykmeldingMessage.sykmelding.id} er ikke en gyldig UUID.")
+        transaction {
+            try {
+                val sykmeldingMessage = jsonMapper.decodeFromString<SendSykmeldingAivenKafkaMessage>(melding)
+                val sykmeldingId =
+                    sykmeldingMessage.sykmelding.id.toUuidOrNull()
+                        ?: throw IllegalArgumentException("Mottatt sykmeldingId ${sykmeldingMessage.sykmelding.id} er ikke en gyldig UUID.")
 
-            val fullPerson = pdlService.hentFullPerson(sykmeldingMessage.kafkaMetadata.fnr, sykmeldingId)
+                val fullPerson = pdlService.hentFullPerson(sykmeldingMessage.kafkaMetadata.fnr, sykmeldingId)
 
-            sykmeldingService.lagreSykmelding(sykmeldingMessage, sykmeldingId, fullPerson.navn.fulltNavn())
-            dokumentkoblingService.produserSykmeldingKobling(
-                sykmeldingId = sykmeldingId,
-                sykmeldingMessage = sykmeldingMessage,
-                fullPerson = fullPerson,
-            )
-        } catch (e: FantIkkePersonException) {
-            logger.error("Fant ikke person i PDL, ignorerer sykmelding!")
-            sikkerLogger.error(
-                "Fant ikke person i PDL med fnr(${e.fnr}), ignorerer sykmelding med id: ${e.sykmeldingId}!",
-                e,
-            )
-        } catch (e: Exception) {
-            // TODO: Skille på exception fra db og kafka
-            "En feil oppstod, avbryter og forsøker igjen".also {
-                logger.error(it)
-                sikkerLogger.error(it, e)
+                sykmeldingService.lagreSykmelding(sykmeldingMessage, sykmeldingId, fullPerson.navn.fulltNavn())
+                dokumentkoblingService.produserSykmeldingKobling(
+                    sykmeldingId = sykmeldingId,
+                    sykmeldingMessage = sykmeldingMessage,
+                    fullPerson = fullPerson,
+                )
+            } catch (e: FantIkkePersonException) {
+                logger.error("Fant ikke person i PDL, ignorerer sykmelding!")
+                sikkerLogger.error(
+                    "Fant ikke person i PDL med fnr(${e.fnr}), ignorerer sykmelding med id: ${e.sykmeldingId}!",
+                    e,
+                )
+            } catch (e: Exception) {
+                // TODO: Skille på andre exceptions fra pdl, fra db og fra kafka
+                "En feil oppstod, avbryter og forsøker igjen".also {
+                    logger.error(it)
+                    sikkerLogger.error(it, e)
+                }
+                rollback()
+                throw e // sørg for at kafka-offset ikke commites dersom vi ikke lagrer i db
             }
-            throw e // sørg for at kafka-offset ikke commites dersom vi ikke lagrer i db
         }
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadService.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadService.kt
@@ -51,16 +51,14 @@ class SoeknadService(
             logger.info("Søknad med id ${soeknad.id} ignoreres fordi den ikke skal lagres eller sendes til arbeidsgiver.")
             return
         }
-
-        if (soeknad.erAlleredeLagret()) {
-            logger.info("Søknad med id ${soeknad.id} ignoreres fordi den allerede er lagret.")
-            return
-        }
-
         try {
             val validertSoeknad = soeknad.validerPaakrevdeFelter()
-            soeknadRepository.lagreSoeknad(validertSoeknad)
-            logger.info("Lagret søknad med id: ${soeknad.id}")
+            if (soeknad.erAlleredeLagret()) {
+                logger.info("Søknad med id ${soeknad.id} er allerede lagret.")
+            } else {
+                soeknadRepository.lagreSoeknad(validertSoeknad)
+                logger.info("Lagret søknad med id: ${soeknad.id}")
+            }
 
             if (soeknad.skalSendesTilArbeidsgiver()) {
                 dokumentkoblingService.produserSykepengesoeknadKobling(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/soeknad/SoeknadServiceTest.kt
@@ -264,7 +264,7 @@ class SoeknadServiceTest {
     }
 
     @Test
-    fun `skal _ikke_ lagre eller videresende søknad dersom det allerede finnes en søknad i databasen med den IDen`() {
+    fun `skal _ikke_ lagre, kun videresende søknad dersom det allerede finnes en søknad i databasen med den IDen`() {
         val soeknad = soeknadMock().medOrgnr(orgnr)
         val soeknadId = UUID.randomUUID()
 
@@ -282,7 +282,8 @@ class SoeknadServiceTest {
         lagredeSoeknader.size shouldBe 1
         lagredeSoeknader.first()?.fom shouldBe soeknadSomSkalLagres.fom
 
-        verify(exactly = 1) {
+        // Vi sender til dialog-app hver gang - dialog-app har egen duplikatsjekk.
+        verify(exactly = 2) {
             dokumentkoblingService.produserSykepengesoeknadKobling(
                 soeknadSomSkalLagres.id,
                 soeknadSomSkalLagres.sykmeldingId.shouldNotBeNull(),


### PR DESCRIPTION
Send sykmelding og søknad til dialog-app, også når de allerede er lagret i database, 
dette er trygt fordi dialog-app har egen duplikatsjekk. 
En bug her gjorde at dersom lagring til db gikk ok, men sending til dialog-app feilet, fikk appen til å ikke committe offset og forsøke meldingen på nytt. 
Da var entitet lagret og ble tatt i duplikatsjekk, og da ble heller ikke dialogmelding sendt. 
Endrer til å uansett sende, men legger også på transaction {} rundt håndteringen, så forsøker vi heller hele operasjonen på nytt